### PR TITLE
fix: serve plain HTTP on :8080 by default, add optional TLS (#1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ USER scanner
 
 COPY --from=builder /app/harbor-scanner-kubescape /usr/local/bin/harbor-scanner-kubescape
 
-EXPOSE 8443
+EXPOSE 8080
 
 ENTRYPOINT ["harbor-scanner-kubescape"]

--- a/README.md
+++ b/README.md
@@ -44,16 +44,40 @@ helm install harbor-scanner-kubescape ./charts/harbor-scanner-kubescape \
 2. Click **+ New Scanner**
 3. Fill in:
    - **Name**: Kubescape
-   - **Endpoint**: `http://harbor-scanner-kubescape.harbor.svc.cluster.local:8443`
+   - **Endpoint**: `http://harbor-scanner-kubescape.harbor.svc.cluster.local:8080`
+     (or `https://...:8443` if you enabled TLS — see [TLS](#tls) below)
 4. Click **Test Connection**, then **Add**
 
 ## Configuration
 
 | Environment Variable | Default | Description |
 |---------------------|---------|-------------|
-| `SCANNER_API_ADDR` | `:8443` | Address for the HTTP server to listen on |
+| `SCANNER_API_ADDR` | `:8080` | Address for the HTTP server to listen on |
+| `SCANNER_API_TLS_CERT` | _(unset)_ | Path to a PEM-encoded TLS certificate. When both cert and key are set, the server uses HTTPS. |
+| `SCANNER_API_TLS_KEY` | _(unset)_ | Path to the PEM-encoded TLS private key. |
 | `KUBEVULN_URL` | `http://kubevuln:8080` | Base URL of the kubevuln service |
 | `KUBEVULN_NAMESPACE` | `kubescape` | Kubernetes namespace for Kubescape components |
+
+### TLS
+
+By default the adapter serves plain HTTP on `:8080` and TLS termination is
+expected at the cluster edge (ingress / service mesh). To serve HTTPS directly,
+set both `SCANNER_API_TLS_CERT` and `SCANNER_API_TLS_KEY` to mounted PEM file
+paths and typically set `SCANNER_API_ADDR` to `:8443`.
+
+When deploying with the Helm chart, enable TLS via:
+
+```bash
+kubectl create secret tls harbor-scanner-kubescape-tls \
+  --cert=path/to/tls.crt --key=path/to/tls.key -n harbor
+
+helm install harbor-scanner-kubescape ./charts/harbor-scanner-kubescape \
+  --namespace harbor \
+  --set tls.enabled=true \
+  --set tls.secretName=harbor-scanner-kubescape-tls \
+  --set scanner.apiAddr=":8443" \
+  --set service.port=8443
+```
 
 ## Development
 

--- a/charts/harbor-scanner-kubescape/templates/deployment.yaml
+++ b/charts/harbor-scanner-kubescape/templates/deployment.yaml
@@ -30,24 +30,44 @@ spec:
               value: {{ .Values.scanner.kubevulnURL | quote }}
             - name: KUBEVULN_NAMESPACE
               value: {{ .Values.scanner.kubevulnNamespace | quote }}
+            {{- if .Values.tls.enabled }}
+            - name: SCANNER_API_TLS_CERT
+              value: "/etc/harbor-scanner-kubescape/tls/tls.crt"
+            - name: SCANNER_API_TLS_KEY
+              value: "/etc/harbor-scanner-kubescape/tls/tls.key"
+            {{- end }}
           ports:
-            - name: http
-              containerPort: 8443
+            - name: api
+              containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- if .Values.tls.enabled }}
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/harbor-scanner-kubescape/tls
+              readOnly: true
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /probe/healthy
-              port: http
+              port: api
+              scheme: {{ if .Values.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}
             initialDelaySeconds: 5
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /probe/ready
-              port: http
+              port: api
+              scheme: {{ if .Values.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}
             initialDelaySeconds: 5
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.tls.enabled }}
+      volumes:
+        - name: tls
+          secret:
+            secretName: {{ required "tls.secretName is required when tls.enabled is true" .Values.tls.secretName }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/harbor-scanner-kubescape/templates/service.yaml
+++ b/charts/harbor-scanner-kubescape/templates/service.yaml
@@ -8,8 +8,9 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: api
       protocol: TCP
-      name: http
+      name: api
+      appProtocol: {{ if .Values.tls.enabled }}https{{ else }}http{{ end }}
   selector:
     {{- include "harbor-scanner-kubescape.selectorLabels" . | nindent 4 }}

--- a/charts/harbor-scanner-kubescape/values.yaml
+++ b/charts/harbor-scanner-kubescape/values.yaml
@@ -10,16 +10,26 @@ fullnameOverride: ""
 
 service:
   type: ClusterIP
-  port: 8443
+  port: 8080
 
 # Scanner adapter configuration
 scanner:
-  # Address to listen on
-  apiAddr: ":8443"
+  # Address to listen on. Default is plain HTTP on :8080. If tls.enabled is
+  # true, set this to ":8443" (or your preferred TLS port).
+  apiAddr: ":8080"
   # Base URL of the kubevuln service in the cluster
   kubevulnURL: "http://kubevuln.kubescape.svc.cluster.local:8080"
   # Kubernetes namespace where Kubescape components run
   kubevulnNamespace: "kubescape"
+
+# TLS configuration. When enabled, the scanner serves HTTPS using the cert/key
+# from the referenced Secret (which must contain `tls.crt` and `tls.key` keys,
+# i.e. a kubernetes.io/tls Secret). When disabled, the scanner serves plain
+# HTTP and TLS termination is expected at the ingress / service mesh layer.
+tls:
+  enabled: false
+  # Name of an existing kubernetes.io/tls Secret in the same namespace.
+  secretName: ""
 
 resources:
   limits:

--- a/cmd/scanner-kubescape/main.go
+++ b/cmd/scanner-kubescape/main.go
@@ -103,9 +103,21 @@ func run(ctx context.Context, cfg config.Config, buildInfo config.BuildInfo) err
 		close(shutdownComplete)
 	}()
 
-	slog.Info("Listening", slog.String("addr", cfg.API.Addr))
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		return err
+	if cfg.API.TLSEnabled() {
+		slog.Info("Listening (TLS)",
+			slog.String("addr", cfg.API.Addr),
+			slog.String("cert", cfg.API.TLSCertFile),
+		)
+		if err := srv.ListenAndServeTLS(cfg.API.TLSCertFile, cfg.API.TLSKeyFile); err != nil && err != http.ErrServerClosed {
+			return err
+		}
+	} else {
+		slog.Info("Listening (plain HTTP — terminate TLS at ingress/service mesh)",
+			slog.String("addr", cfg.API.Addr),
+		)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			return err
+		}
 	}
 
 	<-shutdownComplete

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,8 +18,19 @@ type Config struct {
 }
 
 // APIConfig holds HTTP server configuration.
+//
+// TLSCertFile and TLSKeyFile are optional. When both are set, the server
+// uses HTTPS (ListenAndServeTLS). Otherwise the server uses plain HTTP and
+// callers are expected to terminate TLS at an ingress / service mesh layer.
 type APIConfig struct {
-	Addr string
+	Addr        string
+	TLSCertFile string
+	TLSKeyFile  string
+}
+
+// TLSEnabled reports whether both cert and key paths are set.
+func (a APIConfig) TLSEnabled() bool {
+	return a.TLSCertFile != "" && a.TLSKeyFile != ""
 }
 
 // KubevulnConfig holds configuration for communicating with kubevuln.
@@ -31,10 +42,16 @@ type KubevulnConfig struct {
 }
 
 // Load reads configuration from environment variables with sensible defaults.
+//
+// The default listen address is :8080 (plain HTTP). To enable TLS, set both
+// SCANNER_API_TLS_CERT and SCANNER_API_TLS_KEY to filesystem paths of a
+// PEM-encoded certificate and key, and typically set SCANNER_API_ADDR to :8443.
 func Load() (Config, error) {
 	cfg := Config{
 		API: APIConfig{
-			Addr: envOrDefault("SCANNER_API_ADDR", ":8443"),
+			Addr:        envOrDefault("SCANNER_API_ADDR", ":8080"),
+			TLSCertFile: os.Getenv("SCANNER_API_TLS_CERT"),
+			TLSKeyFile:  os.Getenv("SCANNER_API_TLS_KEY"),
 		},
 		Kubevuln: KubevulnConfig{
 			URL:       envOrDefault("KUBEVULN_URL", "http://kubevuln:8080"),


### PR DESCRIPTION
## Summary

Fixes #1 — Dockerfile previously exposed port 8443 implying HTTPS, but `main.go` started a plain HTTP server. Any party with network visibility between Harbor and the scanner could intercept registry credentials in cleartext.

This PR makes the defaults internally consistent and adds optional in-process TLS:

- Default listener is now plain HTTP on `:8080` (matching the harbor-scanner-trivy reference and standard practice when TLS is terminated at the cluster edge).
- New env vars `SCANNER_API_TLS_CERT` / `SCANNER_API_TLS_KEY`. When both are set, the server uses `http.ListenAndServeTLS`.
- `Dockerfile` now `EXPOSE 8080`.
- Helm chart gains a `tls.enabled` toggle that mounts a `kubernetes.io/tls` Secret, wires the env vars, and switches probe scheme + service `appProtocol` to HTTPS.
- README config table and a new **TLS** section documenting both modes.

## Why two modes?

Both options the issue suggested are legitimate depending on deployment shape: cluster-edge TLS (ingress/service mesh) is more common in production, but in-process TLS is useful when the adapter is exposed directly. The new env vars let either work with no code changes.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./...` passes (no behavior change for existing tests; defaults flipped).
- [ ] Helm template rendered manually — defaults produce HTTP-on-8080 deployment; `--set tls.enabled=true --set tls.secretName=foo` produces HTTPS deployment with mounted Secret and HTTPS probes.
- [ ] Smoke-test the TLS path locally with a self-signed cert.