### PR TITLE
chart: fail install on replicaCount > 1, add NOTES.txt warning (#2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binaries
-harbor-scanner-kubescape
+/harbor-scanner-kubescape
 *.exe
 *.exe~
 *.dll

--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ helm install harbor-scanner-kubescape ./charts/harbor-scanner-kubescape \
   --set service.port=8443
 ```
 
+### Replicas
+
+Scan state is held in an in-memory store, so the chart only supports
+`replicaCount: 1`. Installing with a higher replica count is rejected by a
+chart-level validation; you can opt out via `--set acknowledgeUnsafeMultiReplica=true`
+but Harbor polls will return 404 for jobs that landed on a different replica.
+See [#2](https://github.com/goharbor/harbor-scanner-kubescape/issues/2) for the
+shared-backend plan.
+
 ## Development
 
 ### Build

--- a/charts/harbor-scanner-kubescape/templates/NOTES.txt
+++ b/charts/harbor-scanner-kubescape/templates/NOTES.txt
@@ -1,0 +1,24 @@
+harbor-scanner-kubescape installed.
+
+{{- if gt (int .Values.replicaCount) 1 }}
+
+WARNING: replicaCount is {{ .Values.replicaCount }} but this release was installed with
+acknowledgeUnsafeMultiReplica=true. Scan state is held in an in-memory store
+(pkg/persistence/memory) and is not shared across pods. Harbor's polling
+requests will land on different replicas and return 404 for jobs accepted by
+another replica. Until a shared backend (e.g. Redis) is wired up, this is a
+known-broken configuration — do not use it in production.
+
+{{- else }}
+
+The adapter is running with replicaCount=1, the only currently supported
+configuration. See https://github.com/goharbor/harbor-scanner-kubescape/issues/2
+for the multi-replica plan.
+
+{{- end }}
+
+Register the scanner in Harbor:
+
+  Endpoint: http://{{ include "harbor-scanner-kubescape.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+Then go to Harbor Admin -> Interrogation Services -> Scanners -> + New Scanner.

--- a/charts/harbor-scanner-kubescape/templates/deployment.yaml
+++ b/charts/harbor-scanner-kubescape/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and (gt (int .Values.replicaCount) 1) (not .Values.acknowledgeUnsafeMultiReplica) -}}
+{{- fail "replicaCount > 1 is not safe: scan state is held in-memory and is not shared across pods, causing Harbor polls to 404 on jobs accepted by other replicas. Set acknowledgeUnsafeMultiReplica=true to override (and accept the broken behavior), or keep replicaCount: 1. See https://github.com/goharbor/harbor-scanner-kubescape/issues/2." -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/harbor-scanner-kubescape/values.yaml
+++ b/charts/harbor-scanner-kubescape/values.yaml
@@ -1,5 +1,13 @@
 replicaCount: 1
 
+# Scan state is held in an in-memory store and is not shared across pods, so
+# Harbor's polling requests can land on a replica that has no record of the
+# job and return 404. The chart fails installation if replicaCount > 1 unless
+# this flag is set to true, in which case you accept the broken-by-design
+# behavior. Track https://github.com/goharbor/harbor-scanner-kubescape/issues/2
+# for the shared-backend (Redis/etc.) plan.
+acknowledgeUnsafeMultiReplica: false
+
 image:
   repository: ghcr.io/goharbor/harbor-scanner-kubescape
   tag: ""  # Defaults to Chart appVersion

--- a/pkg/persistence/memory/store.go
+++ b/pkg/persistence/memory/store.go
@@ -10,7 +10,13 @@ import (
 )
 
 // Store is an in-memory implementation of persistence.Store.
-// Suitable for single-instance deployments. For HA, replace with Redis.
+//
+// Single-instance only. Scan state is not shared across pods, so any
+// multi-replica deployment will return 404 on Harbor poll requests that land
+// on a replica different from the one that accepted the scan. The Helm chart
+// fails installation when replicaCount > 1 unless explicitly overridden — see
+// https://github.com/goharbor/harbor-scanner-kubescape/issues/2 for the
+// shared-backend (Redis/etc.) plan.
 type Store struct {
 	mu   sync.RWMutex
 	jobs map[string]*persistence.ScanJob


### PR DESCRIPTION
## Summary

Fixes #2 — scan state is in-memory, so any deploy with replicaCount > 1 silently 404s on Harbor polls that hit a different replica than the one that accepted the scan.

This PR makes that constraint loud at install time rather than silently broken at runtime:

- Helm install **fails** when \`replicaCount > 1\` unless the user explicitly opts in via \`--set acknowledgeUnsafeMultiReplica=true\` (and accepts the documented broken behavior).
- New \`NOTES.txt\` confirms the safe case and warns clearly when the override is used.
- README gains a **Replicas** subsection pointing at this issue.
- \`pkg/persistence/memory/store.go\` doc comment updated to reference the issue and the shared-backend plan.

## Drive-by .gitignore fix

While adding \`NOTES.txt\` I noticed the chart directory was silently ignored: the unanchored \`harbor-scanner-kubescape\` line in \`.gitignore\` was matching \`charts/harbor-scanner-kubescape/\` as well as the top-level binary. Anchored it to \`/harbor-scanner-kubescape\` — existing tracked chart files were unaffected, but new chart files (like the new \`NOTES.txt\`) would have been silently dropped without this fix.

## Why \`fail\` rather than just a warning?

The issue calls this \"silently broken in HA\" — a NOTES.txt warning preserves the silence (operators rarely read it). A hard \`fail\` forces the conversation. The override flag is there for users who genuinely understand the consequence and want to test the multi-replica path.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` passes.
- [ ] \`helm template . --set replicaCount=2\` produces a hard \`fail\` from the deployment template.
- [ ] \`helm template . --set replicaCount=2 --set acknowledgeUnsafeMultiReplica=true\` renders successfully and \`NOTES.txt\` shows the warning.
- [ ] \`helm template .\` with defaults renders successfully and shows the safe-case message.