### PR TITLE
fix: error when k8s client unavailable instead of false-clean report (#6)

### DIFF
--- a/cmd/scanner-kubescape/main.go
+++ b/cmd/scanner-kubescape/main.go
@@ -73,7 +73,10 @@ func run(ctx context.Context, cfg config.Config, buildInfo config.BuildInfo) err
 			slog.String("api_server", baseURL),
 		)
 	} else {
-		slog.Warn("Not running in Kubernetes cluster, VulnerabilityManifest CRD lookup disabled")
+		slog.Warn("Not running in Kubernetes cluster — VulnerabilityManifest CRD lookup disabled. " +
+			"Scan requests will fail with HTTP 500 until k8s access is provided. " +
+			"This warning is expected for local dev; in production, ensure the pod has " +
+			"a service account with read access to vulnerabilitymanifests.spdx.softwarecomposition.kubescape.io.")
 	}
 
 	controller := scan.NewController(store, scanner, k8sClient, cfg.Kubevuln.Namespace)

--- a/pkg/scan/controller.go
+++ b/pkg/scan/controller.go
@@ -60,6 +60,14 @@ func (c *controller) Scan(ctx context.Context, scanJobID string) error {
 	return nil
 }
 
+// ErrK8sUnavailable is returned when the controller cannot read
+// VulnerabilityManifest CRDs from Kubernetes. The adapter cannot observe scan
+// results in this state, so propagating an error is the correct behavior —
+// returning a placeholder zero-vulnerability report would be a security-
+// relevant false negative (Harbor would mark images clean that were never
+// scanned). See issue #6.
+var ErrK8sUnavailable = fmt.Errorf("kubernetes client unavailable: cannot observe VulnerabilityManifest CRDs")
+
 func (c *controller) scan(ctx context.Context, scanJobID string) error {
 	job, err := c.store.Get(ctx, scanJobID)
 	if err != nil {
@@ -67,6 +75,10 @@ func (c *controller) scan(ctx context.Context, scanJobID string) error {
 	}
 	if job == nil {
 		return fmt.Errorf("scan job not found: %s", scanJobID)
+	}
+
+	if c.k8sClient == nil {
+		return ErrK8sUnavailable
 	}
 
 	if err := c.store.UpdateStatus(ctx, scanJobID, persistence.Pending); err != nil {
@@ -83,23 +95,21 @@ func (c *controller) scan(ctx context.Context, scanJobID string) error {
 	)
 
 	// Step 1: Check if VulnerabilityManifest already exists
-	if c.k8sClient != nil {
-		existing, err := c.k8sClient.GetVulnerabilityManifest(ctx, c.namespace, crdName)
-		if err != nil {
-			slog.Warn("Failed to check existing VulnerabilityManifest, will trigger new scan",
-				slog.String("err", err.Error()),
-			)
-		} else if existing != nil && len(existing.Matches) > 0 {
-			slog.Info("Found existing VulnerabilityManifest, reusing results",
-				slog.String("crd_name", crdName),
-				slog.Int("matches", len(existing.Matches)),
-			)
-			report := TransformManifestToReport(existing, job.Request.Artifact)
-			if err := c.store.UpdateReport(ctx, scanJobID, report); err != nil {
-				return err
-			}
-			return c.store.UpdateStatus(ctx, scanJobID, persistence.Finished)
+	existing, err := c.k8sClient.GetVulnerabilityManifest(ctx, c.namespace, crdName)
+	if err != nil {
+		slog.Warn("Failed to check existing VulnerabilityManifest, will trigger new scan",
+			slog.String("err", err.Error()),
+		)
+	} else if existing != nil && len(existing.Matches) > 0 {
+		slog.Info("Found existing VulnerabilityManifest, reusing results",
+			slog.String("crd_name", crdName),
+			slog.Int("matches", len(existing.Matches)),
+		)
+		report := TransformManifestToReport(existing, job.Request.Artifact)
+		if err := c.store.UpdateReport(ctx, scanJobID, report); err != nil {
+			return err
 		}
+		return c.store.UpdateStatus(ctx, scanJobID, persistence.Finished)
 	}
 
 	// Step 2: No existing CRD — trigger kubevuln scan
@@ -112,20 +122,12 @@ func (c *controller) scan(ctx context.Context, scanJobID string) error {
 	}
 
 	// Step 3: Poll for VulnerabilityManifest CRD
-	if c.k8sClient != nil {
-		report, err := c.pollForResults(ctx, crdName, job.Request.Artifact)
-		if err != nil {
-			return fmt.Errorf("waiting for scan results: %w", err)
-		}
-		if err := c.store.UpdateReport(ctx, scanJobID, report); err != nil {
-			return err
-		}
-	} else {
-		// No K8s client available (e.g., local dev) — store a placeholder
-		report := BuildPlaceholderReport(job.Request.Artifact)
-		if err := c.store.UpdateReport(ctx, scanJobID, report); err != nil {
-			return err
-		}
+	report, err := c.pollForResults(ctx, crdName, job.Request.Artifact)
+	if err != nil {
+		return fmt.Errorf("waiting for scan results: %w", err)
+	}
+	if err := c.store.UpdateReport(ctx, scanJobID, report); err != nil {
+		return err
 	}
 
 	if err := c.store.UpdateStatus(ctx, scanJobID, persistence.Finished); err != nil {

--- a/pkg/scan/controller_test.go
+++ b/pkg/scan/controller_test.go
@@ -1,0 +1,61 @@
+package scan
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/goharbor/harbor-scanner-kubescape/pkg/harbor"
+	"github.com/goharbor/harbor-scanner-kubescape/pkg/persistence"
+	"github.com/goharbor/harbor-scanner-kubescape/pkg/persistence/memory"
+)
+
+// TestScan_NoK8sClient_ReturnsError pins the security-relevant fix from #6:
+// when the k8s client is nil the controller must error rather than silently
+// store a placeholder zero-vulnerability report. Otherwise Harbor would mark
+// the image clean even though the scan never ran.
+func TestScan_NoK8sClient_ReturnsError(t *testing.T) {
+	store := memory.NewStore()
+	ctx := context.Background()
+
+	job := persistence.ScanJob{
+		ID: "job-no-k8s",
+		Request: harbor.ScanRequest{
+			Registry: harbor.Registry{URL: "https://registry.example.com"},
+			Artifact: harbor.Artifact{
+				Repository: "library/nginx",
+				Digest:     "sha256:abcdef0123456789",
+			},
+		},
+		Status: persistence.Queued,
+	}
+	if err := store.Create(ctx, job); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// k8sClient explicitly nil; scanner is also nil because we should error
+	// before reaching it.
+	c := NewController(store, nil, nil, "kubescape")
+
+	err := c.Scan(ctx, job.ID)
+	if err == nil {
+		t.Fatal("expected error when k8sClient is nil, got nil (Harbor would receive a false-clean report)")
+	}
+	if !errors.Is(err, ErrK8sUnavailable) {
+		t.Errorf("expected ErrK8sUnavailable, got %v", err)
+	}
+
+	got, err := store.Get(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != persistence.Failed {
+		t.Errorf("expected job status Failed, got %s", got.Status)
+	}
+	if got.Error == "" {
+		t.Errorf("expected job.Error to be populated with the failure reason")
+	}
+	if len(got.Report.Vulnerabilities) > 0 {
+		t.Errorf("expected no report on failure, got %d vulnerabilities", len(got.Report.Vulnerabilities))
+	}
+}

--- a/pkg/scan/transformer.go
+++ b/pkg/scan/transformer.go
@@ -2,7 +2,6 @@ package scan
 
 import (
 	"strings"
-	"time"
 
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/harbor"
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/k8s"
@@ -69,21 +68,6 @@ func TransformManifestToReport(vm *k8s.VulnerabilityManifest, artifact harbor.Ar
 	}
 
 	return report
-}
-
-// BuildPlaceholderReport creates a minimal report for when kubevuln has been triggered
-// but VulnerabilityManifest CRD is not yet available.
-func BuildPlaceholderReport(artifact harbor.Artifact) harbor.ScanReport {
-	return harbor.ScanReport{
-		GeneratedAt: time.Now().UTC(),
-		Artifact:    artifact,
-		Scanner: harbor.Scanner{
-			Name:    "Kubescape",
-			Vendor:  "ARMO",
-			Version: "v3.0.0",
-		},
-		Vulnerabilities: []harbor.VulnerabilityItem{},
-	}
 }
 
 var severityMap = map[string]harbor.Severity{


### PR DESCRIPTION
## Summary

Fixes #6 — when the Kubernetes client was unavailable the controller stored a placeholder zero-vulnerability report and marked the scan Finished. Harbor would then mark the image clean even though the scan never ran. False clean = security-relevant false negative.

This PR:

- Fails the scan with a typed \`ErrK8sUnavailable\` when \`k8sClient\` is nil, before any kubevuln request is sent. The existing async-failure path stores the error on the job, and \`GET /api/v1/scan/{id}/report\` surfaces it as HTTP 500.
- Removes \`BuildPlaceholderReport\` entirely. It had no remaining caller and its purpose was the silent-clean path itself.
- Sharpens the startup warning so operators know the adapter is non-functional until k8s access is provided.

## Test coverage

New \`pkg/scan/controller_test.go::TestScan_NoK8sClient_ReturnsError\` pins the behavior:

1. Construct a controller with a nil k8s client.
2. Run a scan.
3. Assert: error is \`ErrK8sUnavailable\`, job status is \`Failed\`, job.Error is set, and no vulnerabilities are reported.

This test would fail under the old code (it would pass with a \`Finished\` status and a clean placeholder).

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` passes including the new controller test.
- [ ] End-to-end: with a misconfigured pod (no service account token), confirm Harbor receives HTTP 500 with a clear message rather than a clean report.