### PR TITLE
fix: normalize image reference before computing slug (#4)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 )
+
+require (
+	github.com/google/go-containerregistry v0.19.2
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
+github.com/google/go-containerregistry v0.19.2 h1:TannFKE1QSajsP6hPWb5oJNgKe1IKjHukIKDUmvsV6w=
+github.com/google/go-containerregistry v0.19.2/go.mod h1:YCMFNQeeXeLF+dnhhWkqDItx/JSkH01j1Kis4PsjzFI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=

--- a/pkg/scan/scanner.go
+++ b/pkg/scan/scanner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/config"
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/harbor"
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/k8s"
+	"github.com/google/go-containerregistry/pkg/name"
 )
 
 // Scanner interfaces with kubevuln to perform image vulnerability scanning.
@@ -117,15 +118,37 @@ func (s *kubevulnScanner) TriggerScan(ctx context.Context, req harbor.ScanReques
 	return nil
 }
 
-// BuildImageRef constructs a full image reference from a Harbor scan request.
+// BuildImageRef constructs a full image reference from a Harbor scan request,
+// then applies the same normalization that kubevuln applies before computing
+// VulnerabilityManifest CRD names. Without this, shortname inputs (e.g.
+// docker.io/nginx:latest, or any reference that go-containerregistry
+// rewrites) would produce a different slug here than in kubevuln, and the
+// CRD lookup would never resolve. See issue #4.
 func BuildImageRef(req harbor.ScanRequest) string {
+	raw := buildRawImageRef(req)
+	return normalizeImageRef(raw)
+}
+
+func buildRawImageRef(req harbor.ScanRequest) string {
 	registryURL, err := url.Parse(req.Registry.URL)
 	if err != nil {
 		return fmt.Sprintf("%s@%s", req.Artifact.Repository, req.Artifact.Digest)
 	}
-
 	host := registryURL.Host
 	return fmt.Sprintf("%s/%s@%s", host, req.Artifact.Repository, req.Artifact.Digest)
+}
+
+// normalizeImageRef mirrors kubevuln's tools.NormalizeReference: parse the
+// input via go-containerregistry's name package and return its canonical
+// Name(). For fully-qualified Harbor inputs this is a no-op; for shortnames
+// it expands to the canonical docker.io form. If parsing fails we return the
+// input unchanged so we never break a working slug computation.
+func normalizeImageRef(ref string) string {
+	parsed, err := name.ParseReference(ref)
+	if err != nil {
+		return ref
+	}
+	return parsed.Name()
 }
 
 // ImageSlugForRequest generates the VulnerabilityManifest CRD name for a Harbor scan request.

--- a/pkg/scan/scanner_test.go
+++ b/pkg/scan/scanner_test.go
@@ -1,0 +1,98 @@
+package scan
+
+import (
+	"testing"
+
+	"github.com/goharbor/harbor-scanner-kubescape/pkg/harbor"
+)
+
+// TestBuildImageRef_NormalizesReference pins the fix from issue #4: the slug
+// we compute on the adapter side must match the one kubevuln computes after
+// applying tools.NormalizeReference. For fully-qualified inputs (the common
+// Harbor case) this is a no-op; for shortnames it must expand.
+func TestBuildImageRef_NormalizesReference(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      harbor.ScanRequest
+		expected string
+	}{
+		{
+			name: "fully-qualified Harbor reference is unchanged",
+			req: harbor.ScanRequest{
+				Registry: harbor.Registry{URL: "https://core.harbor.domain"},
+				Artifact: harbor.Artifact{
+					Repository: "library/nginx",
+					Digest:     "sha256:abcdef0123456789",
+				},
+			},
+			expected: "core.harbor.domain/library/nginx@sha256:abcdef0123456789",
+		},
+		{
+			name: "registry with port preserved",
+			req: harbor.ScanRequest{
+				Registry: harbor.Registry{URL: "https://myregistry.com:5000"},
+				Artifact: harbor.Artifact{
+					Repository: "myapp/service",
+					Digest:     "sha256:abcdef1234567890",
+				},
+			},
+			expected: "myregistry.com:5000/myapp/service@sha256:abcdef1234567890",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := BuildImageRef(tc.req)
+			if got != tc.expected {
+				t.Errorf("BuildImageRef = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestNormalizeImageRef_ExpandsShortnames covers the scenario the issue
+// flags as broken: if anything ever feeds a docker.io shortname into the
+// path, kubevuln expands it to index.docker.io/library/... and our slug
+// must match.
+func TestNormalizeImageRef_ExpandsShortnames(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "docker.io shortname expands to index.docker.io/library",
+			input:    "nginx:latest",
+			expected: "index.docker.io/library/nginx:latest",
+		},
+		{
+			name:     "user/repo shortname expands to index.docker.io",
+			input:    "bitnami/redis:7.0",
+			expected: "index.docker.io/bitnami/redis:7.0",
+		},
+		{
+			name:     "fully qualified reference is a no-op",
+			input:    "core.harbor.domain/library/nginx@sha256:abc123",
+			expected: "core.harbor.domain/library/nginx@sha256:abc123",
+		},
+		{
+			name:     "registry with port is a no-op",
+			input:    "myregistry.com:5000/myapp@sha256:abc123",
+			expected: "myregistry.com:5000/myapp@sha256:abc123",
+		},
+		{
+			name:     "unparseable input returned unchanged",
+			input:    "::not-a-valid-ref::",
+			expected: "::not-a-valid-ref::",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeImageRef(tc.input)
+			if got != tc.expected {
+				t.Errorf("normalizeImageRef(%q) = %q, want %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #4 — kubevuln runs \`tools.NormalizeReference()\` (a thin wrapper over go-containerregistry's \`name.ParseReference().Name()\`) on every imageTag before deriving the \`VulnerabilityManifest\` CRD name. The adapter computed its slug from the raw input without that step.

For the common Harbor case (fully-qualified hostname) the normalization is a no-op, so slugs match. But any input go-containerregistry rewrites — most importantly docker.io shortnames like \`nginx:latest\`, which expand to \`index.docker.io/library/nginx:latest\` — produced a different slug here than in kubevuln, so the CRD lookup never resolved and every such scan timed out at the 10-minute deadline.

This PR applies the same normalization to \`BuildImageRef\`. If parsing fails we return the raw ref unchanged so a malformed-but-otherwise-working slug path never breaks.

## New tests

\`pkg/scan/scanner_test.go\` covers:

- fully qualified references (no-op);
- docker.io shortname expansion (\`nginx:latest\` → \`index.docker.io/library/nginx:latest\`, \`bitnami/redis:7.0\` → \`index.docker.io/bitnami/redis:7.0\`);
- registry-with-port preserved;
- digest-style refs preserved;
- unparseable input falls back to raw value.

## Dependency

Adds \`github.com/google/go-containerregistry@v0.19.2\` — pinned to a Go 1.22-compatible release line so the module's \`go 1.22\` directive and the \`golang:1.22-alpine\` Dockerfile base don't need to move.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` passes including the new normalize tests.
- [ ] End-to-end: feed a docker.io shortname through the adapter and confirm the CRD lookup resolves.