### PR TITLE
fix: extract CWE IDs from VulnerabilityManifest into Harbor report (#5)

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -36,6 +36,12 @@ type VulnMatch struct {
 	PkgType     string
 	PkgLanguage string
 	CVSS        []VulnCVSS
+	// CweIDs is the deduplicated list of CWE identifiers associated with this
+	// match. Sourced from the top-level vulnerability and any related
+	// vulnerabilities in the Grype payload (NVD-derived CWEs typically appear
+	// on the relatedVulnerabilities entry rather than on the matched
+	// vulnerability itself).
+	CweIDs []string
 }
 
 // VulnCVSS holds CVSS data from a vulnerability match.

--- a/pkg/k8s/rest_client.go
+++ b/pkg/k8s/rest_client.go
@@ -88,26 +88,39 @@ type crdResponse struct {
 	} `json:"spec"`
 }
 
+type crdCvss struct {
+	Version string `json:"version"`
+	Vector  string `json:"vector"`
+	Metrics struct {
+		BaseScore float64 `json:"baseScore"`
+	} `json:"metrics"`
+}
+
+type crdRelatedVulnerability struct {
+	ID         string   `json:"id"`
+	DataSource string   `json:"dataSource"`
+	Namespace  string   `json:"namespace"`
+	Cwes       []string `json:"cwes"`
+}
+
 type crdMatch struct {
 	Vulnerability struct {
-		ID          string   `json:"id"`
-		DataSource  string   `json:"dataSource"`
-		Severity    string   `json:"severity"`
-		URLs        []string `json:"urls"`
-		Description string   `json:"description"`
-		Cvss        []struct {
-			Version string `json:"version"`
-			Vector  string `json:"vector"`
-			Metrics struct {
-				BaseScore float64 `json:"baseScore"`
-			} `json:"metrics"`
-		} `json:"cvss"`
-		Fix struct {
+		ID          string    `json:"id"`
+		DataSource  string    `json:"dataSource"`
+		Severity    string    `json:"severity"`
+		URLs        []string  `json:"urls"`
+		Description string    `json:"description"`
+		Cvss        []crdCvss `json:"cvss"`
+		Fix         struct {
 			Versions []string `json:"versions"`
 			State    string   `json:"state"`
 		} `json:"fix"`
+		// Some Grype vulnerabilities carry CWEs directly; most NVD-derived
+		// CWEs live on relatedVulnerabilities below. Both are captured.
+		Cwes []string `json:"cwes"`
 	} `json:"vulnerability"`
-	Artifact struct {
+	RelatedVulnerabilities []crdRelatedVulnerability `json:"relatedVulnerabilities"`
+	Artifact               struct {
 		Name     string `json:"name"`
 		Version  string `json:"version"`
 		Type     string `json:"type"`
@@ -217,6 +230,7 @@ func crdToManifest(crd crdResponse) *VulnerabilityManifest {
 			PkgVersion:  m.Artifact.Version,
 			PkgType:     m.Artifact.Type,
 			PkgLanguage: m.Artifact.Language,
+			CweIDs:      collectCweIDs(m),
 		}
 		for _, c := range m.Vulnerability.Cvss {
 			match.CVSS = append(match.CVSS, VulnCVSS{
@@ -229,4 +243,32 @@ func crdToManifest(crd crdResponse) *VulnerabilityManifest {
 	}
 
 	return vm
+}
+
+// collectCweIDs returns the union (preserving first-seen order) of CWE IDs on
+// the matched vulnerability and on each related vulnerability. Returns nil
+// when no CWEs are present so the harbor.VulnerabilityItem.CweIDs JSON tag
+// (omitempty) drops the field cleanly.
+func collectCweIDs(m crdMatch) []string {
+	seen := make(map[string]struct{})
+	var out []string
+
+	add := func(ids []string) {
+		for _, id := range ids {
+			if id == "" {
+				continue
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			out = append(out, id)
+		}
+	}
+
+	add(m.Vulnerability.Cwes)
+	for _, rv := range m.RelatedVulnerabilities {
+		add(rv.Cwes)
+	}
+	return out
 }

--- a/pkg/k8s/rest_client_test.go
+++ b/pkg/k8s/rest_client_test.go
@@ -1,0 +1,138 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestGetVulnerabilityManifest_CweExtraction pins the fix from issue #5: CWE
+// IDs in the Grype payload — whether on the matched vulnerability itself or
+// inside relatedVulnerabilities — must end up on VulnMatch.CweIDs and be
+// deduplicated with order preserved.
+func TestGetVulnerabilityManifest_CweExtraction(t *testing.T) {
+	const crdJSON = `{
+	  "metadata": {
+	    "name": "core.harbor.domain-library-nginx-abc123",
+	    "namespace": "kubescape",
+	    "creationTimestamp": "2026-04-30T12:00:00Z"
+	  },
+	  "spec": {
+	    "metadata": {
+	      "tool": {"name":"grype","version":"0.74.0","databaseVersion":"v6"},
+	      "report": {"createdAt":"2026-04-30T12:00:00Z"}
+	    },
+	    "payload": {
+	      "matches": [
+	        {
+	          "vulnerability": {
+	            "id": "CVE-2024-1111",
+	            "severity": "High",
+	            "description": "...",
+	            "urls": ["https://nvd.nist.gov/vuln/detail/CVE-2024-1111"],
+	            "cwes": ["CWE-79"],
+	            "fix": {"versions":["1.2.4"], "state":"fixed"}
+	          },
+	          "relatedVulnerabilities": [
+	            {
+	              "id": "CVE-2024-1111",
+	              "namespace": "nvd:cpe",
+	              "cwes": ["CWE-79", "CWE-352"]
+	            }
+	          ],
+	          "artifact": {"name":"libfoo","version":"1.2.3","type":"deb"}
+	        },
+	        {
+	          "vulnerability": {
+	            "id": "CVE-2024-2222",
+	            "severity": "Low"
+	          },
+	          "relatedVulnerabilities": [
+	            {
+	              "id": "CVE-2024-2222",
+	              "namespace": "nvd:cpe",
+	              "cwes": ["CWE-200"]
+	            }
+	          ],
+	          "artifact": {"name":"libbar","version":"2.0"}
+	        },
+	        {
+	          "vulnerability": {
+	            "id": "CVE-2024-3333",
+	            "severity": "Medium"
+	          },
+	          "artifact": {"name":"libbaz","version":"3.0"}
+	        }
+	      ]
+	    }
+	  }
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/vulnerabilitymanifests/") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(crdJSON))
+	}))
+	defer srv.Close()
+
+	c := NewRESTClient(srv.URL, "test-token")
+
+	vm, err := c.GetVulnerabilityManifest(context.Background(), "kubescape", "core.harbor.domain-library-nginx-abc123")
+	if err != nil {
+		t.Fatalf("GetVulnerabilityManifest: %v", err)
+	}
+	if vm == nil {
+		t.Fatal("expected manifest, got nil")
+	}
+	if len(vm.Matches) != 3 {
+		t.Fatalf("expected 3 matches, got %d", len(vm.Matches))
+	}
+
+	// Match 1: dedupe across vulnerability.cwes and relatedVulnerabilities.cwes.
+	got := vm.Matches[0].CweIDs
+	want := []string{"CWE-79", "CWE-352"}
+	if !equalStrings(got, want) {
+		t.Errorf("match[0].CweIDs = %v, want %v (deduped union)", got, want)
+	}
+
+	// Match 2: CWEs only on relatedVulnerabilities — should still propagate.
+	got = vm.Matches[1].CweIDs
+	want = []string{"CWE-200"}
+	if !equalStrings(got, want) {
+		t.Errorf("match[1].CweIDs = %v, want %v", got, want)
+	}
+
+	// Match 3: no CWEs anywhere — should be empty (not panic, not nil-ptr).
+	if len(vm.Matches[2].CweIDs) != 0 {
+		t.Errorf("match[2].CweIDs = %v, want empty", vm.Matches[2].CweIDs)
+	}
+
+	// Sanity: make sure we didn't break any other parsing — fix versions etc.
+	if len(vm.Matches[0].FixVersions) != 1 || vm.Matches[0].FixVersions[0] != "1.2.4" {
+		t.Errorf("match[0].FixVersions = %v, want [1.2.4]", vm.Matches[0].FixVersions)
+	}
+
+	// Round-trip the CRD JSON to make sure our parsing didn't drift the schema.
+	var raw map[string]interface{}
+	if err := json.Unmarshal([]byte(crdJSON), &raw); err != nil {
+		t.Errorf("CRD JSON itself is malformed: %v", err)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/scan/transformer.go
+++ b/pkg/scan/transformer.go
@@ -40,6 +40,7 @@ func TransformManifestToReport(vm *k8s.VulnerabilityManifest, artifact harbor.Ar
 			Severity:    sev,
 			Description: m.Description,
 			Links:       m.URLs,
+			CweIDs:      m.CweIDs,
 		}
 
 		// Map CVSS if available

--- a/pkg/scan/transformer_test.go
+++ b/pkg/scan/transformer_test.go
@@ -25,6 +25,7 @@ func TestTransformManifestToReport(t *testing.T) {
 				FixState:    "fixed",
 				PkgName:     "libfoo",
 				PkgVersion:  "1.2.3",
+				CweIDs:      []string{"CWE-79", "CWE-89"},
 				CVSS: []k8s.VulnCVSS{
 					{Version: "3.1", Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", BaseScore: 9.8},
 				},
@@ -87,6 +88,14 @@ func TestTransformManifestToReport(t *testing.T) {
 	if v1.CVSS.ScoreV3 == nil || *v1.CVSS.ScoreV3 != 9.8 {
 		t.Errorf("expected CVSS v3 score 9.8, got %v", v1.CVSS.ScoreV3)
 	}
+	if got, want := v1.CweIDs, []string{"CWE-79", "CWE-89"}; !equalStrings(got, want) {
+		t.Errorf("expected CweIDs %v, got %v", want, got)
+	}
+
+	// Second vulnerability has no CWEs — confirm we don't accidentally invent some.
+	if len(report.Vulnerabilities[1].CweIDs) != 0 {
+		t.Errorf("expected no CweIDs on v2, got %v", report.Vulnerabilities[1].CweIDs)
+	}
 
 	// Check second vulnerability
 	v2 := report.Vulnerabilities[1]
@@ -122,6 +131,18 @@ func TestTransformManifestToReport_Empty(t *testing.T) {
 	if report.Vulnerabilities == nil {
 		t.Error("expected non-nil vulnerabilities slice for JSON serialization")
 	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestMapSeverity(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #5 — \`harbor.VulnerabilityItem.CweIDs\` was always empty because the transformer never read CWE data from the \`VulnerabilityManifest\` Grype payload. Harbor users lost CWE classification kubevuln/Grype had already computed.

## Where the data lives

Grype stores CWEs in two places, depending on data source:

- Sometimes directly on the matched vulnerability (\`vulnerability.cwes\`).
- More commonly on each entry in \`relatedVulnerabilities[*].cwes\` — typically the NVD-namespace entry.

This PR reads from both, deduplicates while preserving first-seen order, and returns \`nil\` rather than \`[]\` when there are none so the \`omitempty\` JSON tag drops the field cleanly for clean reports.

## Wiring

- \`pkg/k8s/client.go\` — \`VulnMatch\` gains a \`CweIDs []string\` field.
- \`pkg/k8s/rest_client.go\` — \`crdMatch\` parses \`vulnerability.cwes\` and a new \`relatedVulnerabilities\` slice whose entries each have a \`cwes\` field. New \`collectCweIDs()\` unions both with dedup.
- \`pkg/scan/transformer.go\` — \`TransformManifestToReport\` copies \`CweIDs\` onto \`VulnerabilityItem\`.

## Tests

- \`pkg/k8s/rest_client_test.go\` (new) — end-to-end JSON parse via httptest. Three matches: one with CWEs in both locations (asserts dedup), one with CWEs only on related (asserts propagation), one with none (asserts empty, no panic).
- \`pkg/scan/transformer_test.go\` — existing \`TestTransformManifestToReport\` extended to assert CweIDs flow through and a no-CWE vulnerability stays empty.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` passes including the new CWE tests.
- [ ] End-to-end: scan an image with known CWEs (e.g. log4j) and confirm Harbor's UI displays the CWE classification.