### PR TITLE
chart: render https endpoint in NOTES when tls.enabled is true (#13)

### DIFF
--- a/charts/harbor-scanner-kubescape/templates/NOTES.txt
+++ b/charts/harbor-scanner-kubescape/templates/NOTES.txt
@@ -19,6 +19,6 @@ for the multi-replica plan.
 
 Register the scanner in Harbor:
 
-  Endpoint: http://{{ include "harbor-scanner-kubescape.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+  Endpoint: {{ if .Values.tls.enabled }}https{{ else }}http{{ end }}://{{ include "harbor-scanner-kubescape.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
 
 Then go to Harbor Admin -> Interrogation Services -> Scanners -> + New Scanner.


### PR DESCRIPTION
## Summary

Fixes #13 — \`charts/.../templates/NOTES.txt:22\` rendered \`http://...\` unconditionally even when the chart was configured for HTTPS via \`tls.enabled=true\`. Operators following the post-install hint would register Harbor against the wrong scheme on TLS-enabled installs.

One-line conditional that mirrors the same \`.Values.tls.enabled\` gate already used in \`deployment.yaml\` and \`service.yaml\`.

## Test plan

- [x] \`helm template . --set tls.enabled=false\` prints \`http://...\`.
- [x] \`helm template . --set tls.enabled=true --set tls.secretName=foo\` prints \`https://...\`.