### PR TITLE
fix: readiness probe reflects actual scan capability (#16)

### DIFF
--- a/cmd/scanner-kubescape/main.go
+++ b/cmd/scanner-kubescape/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -80,7 +81,24 @@ func run(ctx context.Context, cfg config.Config, buildInfo config.BuildInfo) err
 	}
 
 	controller := scan.NewController(store, scanner, k8sClient, cfg.Kubevuln.Namespace)
-	handler := v1.NewAPIHandler(buildInfo, cfg, store, controller)
+
+	// Readiness gates. The k8s-client check makes the pod NotReady when the
+	// adapter cannot observe VulnerabilityManifest CRDs, so Kubernetes won't
+	// route Harbor traffic to a pod that would only emit ErrK8sUnavailable.
+	// See issue #16.
+	readiness := []v1.ReadinessCheck{
+		{
+			Name: "kubernetes-client",
+			Check: func() error {
+				if k8sClient == nil {
+					return fmt.Errorf("kubernetes client unavailable; pod cannot read VulnerabilityManifest CRDs")
+				}
+				return nil
+			},
+		},
+	}
+
+	handler := v1.NewAPIHandler(buildInfo, cfg, store, controller, readiness...)
 
 	srv := &http.Server{
 		Addr:         cfg.API.Addr,

--- a/pkg/http/api/v1/handler.go
+++ b/pkg/http/api/v1/handler.go
@@ -29,20 +29,42 @@ const (
 	mimeTypeDockerManifest = "application/vnd.docker.distribution.manifest.v2+json"
 )
 
+// ReadinessCheck returns nil when the named subsystem is ready to serve scan
+// traffic, or an error describing why it is not. Composed in NewAPIHandler so
+// future dependencies (durable store, kubevuln reachability) can layer in
+// without touching the probe handler. See issue #16.
+type ReadinessCheck struct {
+	Name  string
+	Check func() error
+}
+
 type requestHandler struct {
-	buildInfo  config.BuildInfo
-	config     config.Config
-	store      persistence.Store
-	controller scan.Controller
+	buildInfo       config.BuildInfo
+	config          config.Config
+	store           persistence.Store
+	controller      scan.Controller
+	readinessChecks []ReadinessCheck
 }
 
 // NewAPIHandler creates the HTTP handler with all Harbor Scanner API routes.
-func NewAPIHandler(buildInfo config.BuildInfo, cfg config.Config, store persistence.Store, controller scan.Controller) http.Handler {
+//
+// readinessChecks are evaluated on every /probe/ready hit. If any check
+// returns an error the probe responds 503 with a JSON listing the failing
+// subsystems, otherwise 200. /probe/healthy stays 200 unconditionally —
+// liveness reflects the process being up, not its ability to serve.
+func NewAPIHandler(
+	buildInfo config.BuildInfo,
+	cfg config.Config,
+	store persistence.Store,
+	controller scan.Controller,
+	readinessChecks ...ReadinessCheck,
+) http.Handler {
 	h := &requestHandler{
-		buildInfo:  buildInfo,
-		config:     cfg,
-		store:      store,
-		controller: controller,
+		buildInfo:       buildInfo,
+		config:          cfg,
+		store:           store,
+		controller:      controller,
+		readinessChecks: readinessChecks,
 	}
 
 	router := mux.NewRouter()
@@ -208,7 +230,43 @@ func (h *requestHandler) GetHealthy(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (h *requestHandler) GetReady(w http.ResponseWriter, _ *http.Request) {
-	w.WriteHeader(http.StatusOK)
+	type checkResult struct {
+		Name  string `json:"name"`
+		Error string `json:"error,omitempty"`
+		OK    bool   `json:"ok"`
+	}
+
+	results := make([]checkResult, 0, len(h.readinessChecks))
+	allOK := true
+	for _, c := range h.readinessChecks {
+		err := c.Check()
+		results = append(results, checkResult{
+			Name:  c.Name,
+			OK:    err == nil,
+			Error: errString(err),
+		})
+		if err != nil {
+			allOK = false
+		}
+	}
+
+	if allOK {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "checks": results})
+		return
+	}
+
+	slog.Warn("Readiness check failed", slog.Any("checks", results))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusServiceUnavailable)
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "checks": results})
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 func validateScanRequest(req harbor.ScanRequest) error {

--- a/pkg/http/api/v1/handler_test.go
+++ b/pkg/http/api/v1/handler_test.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -236,5 +237,74 @@ func TestHealthProbes(t *testing.T) {
 				t.Errorf("expected 200 for %s, got %d", tc.path, w.Code)
 			}
 		})
+	}
+}
+
+// TestReady_FailingCheck pins issue #16: when a registered readiness check
+// returns an error the probe must respond 503 so Kubernetes routes traffic
+// away from the pod, rather than 200 (which would let Harbor keep hitting
+// a pod that can only emit 500s).
+func TestReady_FailingCheck(t *testing.T) {
+	handler := NewAPIHandler(
+		config.BuildInfo{}, config.Config{}, memory.NewStore(), nil,
+		ReadinessCheck{
+			Name:  "kubernetes-client",
+			Check: func() error { return fmt.Errorf("k8s client unavailable") },
+		},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/probe/ready", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		OK     bool `json:"ok"`
+		Checks []struct {
+			Name  string `json:"name"`
+			OK    bool   `json:"ok"`
+			Error string `json:"error,omitempty"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.OK {
+		t.Errorf("expected ok=false in body, got ok=true")
+	}
+	if len(body.Checks) != 1 || body.Checks[0].Name != "kubernetes-client" || body.Checks[0].OK {
+		t.Errorf("expected one failing kubernetes-client check, got %+v", body.Checks)
+	}
+	if body.Checks[0].Error != "k8s client unavailable" {
+		t.Errorf("expected error message in body, got %q", body.Checks[0].Error)
+	}
+
+	// Liveness must still be 200 — the process is up, it just can't serve.
+	req = httptest.NewRequest(http.MethodGet, "/probe/healthy", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("/probe/healthy must stay 200 even when not ready, got %d", w.Code)
+	}
+}
+
+// TestReady_AllChecksPass confirms the all-pass path returns 200 and lists
+// each successful check by name.
+func TestReady_AllChecksPass(t *testing.T) {
+	handler := NewAPIHandler(
+		config.BuildInfo{}, config.Config{}, memory.NewStore(), nil,
+		ReadinessCheck{Name: "first", Check: func() error { return nil }},
+		ReadinessCheck{Name: "second", Check: func() error { return nil }},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/probe/ready", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #16 — after the #6 fix, the controller fails every scan with \`ErrK8sUnavailable\` when the Kubernetes client could not be initialized, but \`/probe/ready\` still returned 200. Kubernetes would happily route Harbor traffic to a pod that could only emit HTTP 500.

## Approach

\`NewAPIHandler\` now takes a variadic \`ReadinessCheck\` list. Each check has a \`Name\` and a \`func() error\`; \`/probe/ready\` runs them on every hit and responds:

- **200** with \`{\"ok\":true,\"checks\":[...]}\` when all pass.
- **503** with \`{\"ok\":false,\"checks\":[...]}\` when any fail. Failing subsystems are named so an operator can grep logs / kubectl describe to find the cause.

\`/probe/healthy\` stays 200 unconditionally — liveness reflects the process being up, not its ability to serve scans.

\`main.go\` registers a \`kubernetes-client\` check that fails when \`k8sClient == nil\`. The shape is deliberately composable: future checks (durable store reachability after #15, kubevuln health) plug in by appending to the slice.

## Tests

- \`TestReady_FailingCheck\` — registers a failing check; asserts 503 + JSON body lists the failing check by name. Also asserts \`/probe/healthy\` still returns 200 (liveness independence).
- \`TestReady_AllChecksPass\` — multiple passing checks → 200.
- Existing \`TestHealthProbes\` still passes (no checks registered → 200 by default).

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` passes including the new readiness tests.
- [ ] End-to-end: deploy without a service account token, confirm pod stays NotReady.