### PR TITLE
fix: TTL-gated VulnerabilityManifest reuse, applied uniformly (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ helm install harbor-scanner-kubescape ./charts/harbor-scanner-kubescape \
 | `SCANNER_API_TLS_KEY` | _(unset)_ | Path to the PEM-encoded TLS private key. |
 | `KUBEVULN_URL` | `http://kubevuln:8080` | Base URL of the kubevuln service |
 | `KUBEVULN_NAMESPACE` | `kubescape` | Kubernetes namespace for Kubescape components |
+| `SCAN_REUSE_TTL` | `24h` | Freshness window for reusing an existing VulnerabilityManifest CRD. Older CRDs are treated as stale and trigger a fresh scan so newly disclosed CVEs are picked up. Set to `0` to disable reuse. |
 
 ### TLS
 

--- a/cmd/scanner-kubescape/main.go
+++ b/cmd/scanner-kubescape/main.go
@@ -80,7 +80,10 @@ func run(ctx context.Context, cfg config.Config, buildInfo config.BuildInfo) err
 			"a service account with read access to vulnerabilitymanifests.spdx.softwarecomposition.kubescape.io.")
 	}
 
-	controller := scan.NewController(store, scanner, k8sClient, cfg.Kubevuln.Namespace)
+	slog.Info("Scan controller configured",
+		slog.Duration("reuse_ttl", cfg.Scan.ReuseTTL),
+	)
+	controller := scan.NewController(store, scanner, k8sClient, cfg.Kubevuln.Namespace, cfg.Scan.ReuseTTL)
 
 	// Readiness gates. The k8s-client check makes the pod NotReady when the
 	// adapter cannot observe VulnerabilityManifest CRDs, so Kubernetes won't

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"time"
 )
 
 // BuildInfo holds version information set at build time.
@@ -15,6 +16,15 @@ type BuildInfo struct {
 type Config struct {
 	API      APIConfig
 	Kubevuln KubevulnConfig
+	Scan     ScanConfig
+}
+
+// ScanConfig holds policy knobs for the scan controller.
+type ScanConfig struct {
+	// ReuseTTL is the freshness window for an existing VulnerabilityManifest
+	// CRD. Anything older triggers a fresh scan so newly disclosed CVEs in
+	// the Grype DB get picked up. Zero disables reuse outright. See issue #14.
+	ReuseTTL time.Duration
 }
 
 // APIConfig holds HTTP server configuration.
@@ -57,9 +67,27 @@ func Load() (Config, error) {
 			URL:       envOrDefault("KUBEVULN_URL", "http://kubevuln:8080"),
 			Namespace: envOrDefault("KUBEVULN_NAMESPACE", "kubescape"),
 		},
+		Scan: ScanConfig{
+			ReuseTTL: durationFromEnv("SCAN_REUSE_TTL", 24*time.Hour),
+		},
 	}
 
 	return cfg, nil
+}
+
+// durationFromEnv reads a Go duration from the named env var, falling back to
+// the provided default if unset or unparseable. Examples: "1h", "30m", "0s".
+// "0" or any non-positive duration disables the relevant feature.
+func durationFromEnv(key string, defaultValue time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultValue
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return defaultValue
+	}
+	return d
 }
 
 func envOrDefault(key, defaultValue string) string {

--- a/pkg/scan/controller.go
+++ b/pkg/scan/controller.go
@@ -16,10 +16,17 @@ const (
 	pollInterval = 5 * time.Second
 	// Maximum time to wait for a scan to complete.
 	pollTimeout = 10 * time.Minute
+	// DefaultReuseTTL is the default freshness window for reusing an existing
+	// VulnerabilityManifest. Anything older triggers a fresh scan so newly
+	// disclosed CVEs in the Grype DB get picked up. See issue #14.
+	DefaultReuseTTL = 24 * time.Hour
 )
 
+// now is overridable in tests. Production always uses time.Now.
+var now = time.Now
+
 // Controller orchestrates the scanning workflow:
-// 1. Check if VulnerabilityManifest CRD already exists for the image
+// 1. Check if a fresh VulnerabilityManifest CRD already exists for the image
 // 2. If yes, transform and return it
 // 3. If no, trigger kubevuln ScanCVE, then poll for the CRD
 type Controller interface {
@@ -31,15 +38,22 @@ type controller struct {
 	scanner   Scanner
 	k8sClient k8s.Client
 	namespace string
+	reuseTTL  time.Duration
 }
 
 // NewController creates a new scan controller.
-func NewController(store persistence.Store, scanner Scanner, k8sClient k8s.Client, namespace string) Controller {
+//
+// reuseTTL is the freshness window for an existing VulnerabilityManifest CRD;
+// anything older is treated as stale and triggers a fresh scan. Pass 0 to
+// disable reuse entirely (always rescan), or use DefaultReuseTTL for the
+// recommended default.
+func NewController(store persistence.Store, scanner Scanner, k8sClient k8s.Client, namespace string, reuseTTL time.Duration) Controller {
 	return &controller{
 		store:     store,
 		scanner:   scanner,
 		k8sClient: k8sClient,
 		namespace: namespace,
+		reuseTTL:  reuseTTL,
 	}
 }
 
@@ -94,22 +108,36 @@ func (c *controller) scan(ctx context.Context, scanJobID string) error {
 		slog.String("namespace", c.namespace),
 	)
 
-	// Step 1: Check if VulnerabilityManifest already exists
+	// Step 1: Check if a fresh VulnerabilityManifest already exists. The
+	// freshness check is uniform: a CRD is reusable iff it is younger than
+	// reuseTTL, regardless of whether it carries zero or many matches. The
+	// previous len(Matches) > 0 gate caused two bugs: clean images were
+	// rescanned every time, and vulnerable manifests were reused forever
+	// even after the Grype DB or scanner version changed (issue #14).
 	existing, err := c.k8sClient.GetVulnerabilityManifest(ctx, c.namespace, crdName)
 	if err != nil {
 		slog.Warn("Failed to check existing VulnerabilityManifest, will trigger new scan",
 			slog.String("err", err.Error()),
 		)
-	} else if existing != nil && len(existing.Matches) > 0 {
-		slog.Info("Found existing VulnerabilityManifest, reusing results",
+	} else if existing != nil && c.canReuse(existing) {
+		slog.Info("Found fresh VulnerabilityManifest, reusing results",
 			slog.String("crd_name", crdName),
 			slog.Int("matches", len(existing.Matches)),
+			slog.Time("created_at", existing.CreatedAt),
+			slog.Duration("ttl", c.reuseTTL),
 		)
 		report := TransformManifestToReport(existing, job.Request.Artifact)
 		if err := c.store.UpdateReport(ctx, scanJobID, report); err != nil {
 			return err
 		}
 		return c.store.UpdateStatus(ctx, scanJobID, persistence.Finished)
+	} else if existing != nil {
+		slog.Info("Existing VulnerabilityManifest is stale, triggering fresh scan",
+			slog.String("crd_name", crdName),
+			slog.Time("created_at", existing.CreatedAt),
+			slog.Duration("age", now().Sub(existing.CreatedAt)),
+			slog.Duration("ttl", c.reuseTTL),
+		)
 	}
 
 	// Step 2: No existing CRD — trigger kubevuln scan
@@ -136,6 +164,20 @@ func (c *controller) scan(ctx context.Context, scanJobID string) error {
 
 	slog.Info("Scan completed", slog.String("scan_job_id", scanJobID))
 	return nil
+}
+
+// canReuse reports whether an existing VulnerabilityManifest is fresh enough
+// to skip a fresh scan. A zero reuseTTL disables reuse outright. A zero or
+// missing CreatedAt is treated as stale — we will not reuse a manifest of
+// unknown age, since we can't tell whether it predates the current Grype DB.
+func (c *controller) canReuse(vm *k8s.VulnerabilityManifest) bool {
+	if c.reuseTTL <= 0 {
+		return false
+	}
+	if vm.CreatedAt.IsZero() {
+		return false
+	}
+	return now().Sub(vm.CreatedAt) < c.reuseTTL
 }
 
 // pollForResults polls the Kubernetes API for the VulnerabilityManifest CRD

--- a/pkg/scan/controller_test.go
+++ b/pkg/scan/controller_test.go
@@ -4,11 +4,39 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/harbor"
+	"github.com/goharbor/harbor-scanner-kubescape/pkg/k8s"
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/persistence"
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/persistence/memory"
 )
+
+// fakeK8sClient is a minimal in-memory k8s.Client for testing the controller.
+// GetVulnerabilityManifest returns the seeded manifest (or nil to simulate not
+// found). TriggerCount is incremented every time the controller asks the
+// scanner to run, which lets tests assert reuse vs rescan decisions.
+type fakeK8sClient struct {
+	manifest *k8s.VulnerabilityManifest
+}
+
+func (f *fakeK8sClient) GetVulnerabilityManifest(_ context.Context, _, _ string) (*k8s.VulnerabilityManifest, error) {
+	return f.manifest, nil
+}
+
+func (f *fakeK8sClient) ListVulnerabilityManifests(_ context.Context, _, _ string) ([]k8s.VulnerabilityManifest, error) {
+	return nil, nil
+}
+
+// fakeScanner increments triggers on every call.
+type fakeScanner struct {
+	triggers int
+}
+
+func (f *fakeScanner) TriggerScan(_ context.Context, _ harbor.ScanRequest) error {
+	f.triggers++
+	return nil
+}
 
 // TestScan_NoK8sClient_ReturnsError pins the security-relevant fix from #6:
 // when the k8s client is nil the controller must error rather than silently
@@ -35,7 +63,7 @@ func TestScan_NoK8sClient_ReturnsError(t *testing.T) {
 
 	// k8sClient explicitly nil; scanner is also nil because we should error
 	// before reaching it.
-	c := NewController(store, nil, nil, "kubescape")
+	c := NewController(store, nil, nil, "kubescape", DefaultReuseTTL)
 
 	err := c.Scan(ctx, job.ID)
 	if err == nil {
@@ -58,4 +86,202 @@ func TestScan_NoK8sClient_ReturnsError(t *testing.T) {
 	if len(got.Report.Vulnerabilities) > 0 {
 		t.Errorf("expected no report on failure, got %d vulnerabilities", len(got.Report.Vulnerabilities))
 	}
+}
+
+// TestCanReuse covers issue #14: an existing VulnerabilityManifest is
+// reusable iff it is younger than reuseTTL, regardless of whether it has
+// matches. A zero TTL disables reuse outright; a zero CreatedAt is treated
+// as stale (we won't reuse a manifest of unknown age).
+func TestCanReuse(t *testing.T) {
+	fixedNow := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	now = func() time.Time { return fixedNow }
+	t.Cleanup(func() { now = time.Now })
+
+	tests := []struct {
+		name      string
+		ttl       time.Duration
+		createdAt time.Time
+		want      bool
+	}{
+		{
+			name:      "fresh manifest within TTL is reusable",
+			ttl:       24 * time.Hour,
+			createdAt: fixedNow.Add(-1 * time.Hour),
+			want:      true,
+		},
+		{
+			name:      "stale manifest beyond TTL is not reusable",
+			ttl:       24 * time.Hour,
+			createdAt: fixedNow.Add(-25 * time.Hour),
+			want:      false,
+		},
+		{
+			name:      "TTL boundary: exactly TTL old is not reusable",
+			ttl:       24 * time.Hour,
+			createdAt: fixedNow.Add(-24 * time.Hour),
+			want:      false,
+		},
+		{
+			name:      "zero TTL disables reuse",
+			ttl:       0,
+			createdAt: fixedNow.Add(-1 * time.Second),
+			want:      false,
+		},
+		{
+			name:      "negative TTL disables reuse",
+			ttl:       -1 * time.Hour,
+			createdAt: fixedNow.Add(-1 * time.Second),
+			want:      false,
+		},
+		{
+			name:      "zero CreatedAt is treated as stale",
+			ttl:       24 * time.Hour,
+			createdAt: time.Time{},
+			want:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &controller{reuseTTL: tc.ttl}
+			got := c.canReuse(&k8s.VulnerabilityManifest{CreatedAt: tc.createdAt})
+			if got != tc.want {
+				t.Errorf("canReuse() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestScan_FreshManifestIsReused pins issue #14: a fresh existing manifest
+// (within TTL) must be reused, and the scanner must NOT be triggered.
+func TestScan_FreshManifestIsReused(t *testing.T) {
+	fixedNow := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	now = func() time.Time { return fixedNow }
+	t.Cleanup(func() { now = time.Now })
+
+	tests := []struct {
+		name    string
+		matches []k8s.VulnMatch
+	}{
+		{
+			name: "fresh non-clean manifest is reused",
+			matches: []k8s.VulnMatch{
+				{ID: "CVE-2024-9999", Severity: "High", PkgName: "libfoo", PkgVersion: "1.0"},
+			},
+		},
+		{
+			// This is the symmetry half of #14: clean (zero matches) used
+			// to be re-scanned every time. After the fix it must be reused.
+			name:    "fresh clean manifest is reused",
+			matches: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := memory.NewStore()
+			ctx := context.Background()
+
+			job := persistence.ScanJob{
+				ID: "job-fresh",
+				Request: harbor.ScanRequest{
+					Registry: harbor.Registry{URL: "https://core.harbor.domain"},
+					Artifact: harbor.Artifact{
+						Repository: "library/nginx",
+						Digest:     "sha256:abcdef0123456789",
+					},
+				},
+				Status: persistence.Queued,
+			}
+			if err := store.Create(ctx, job); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+
+			fakeK8s := &fakeK8sClient{
+				manifest: &k8s.VulnerabilityManifest{
+					Name:        "nginx-fresh",
+					CreatedAt:   fixedNow.Add(-1 * time.Hour),
+					ToolVersion: "0.74.0",
+					Matches:     tc.matches,
+				},
+			}
+			scanner := &fakeScanner{}
+
+			c := NewController(store, scanner, fakeK8s, "kubescape", 24*time.Hour)
+			if err := c.Scan(ctx, job.ID); err != nil {
+				t.Fatalf("Scan: %v", err)
+			}
+
+			if scanner.triggers != 0 {
+				t.Errorf("scanner triggered %d time(s); fresh manifest must be reused, not rescanned", scanner.triggers)
+			}
+
+			got, _ := store.Get(ctx, job.ID)
+			if got.Status != persistence.Finished {
+				t.Errorf("expected job status Finished, got %s", got.Status)
+			}
+			if len(got.Report.Vulnerabilities) != len(tc.matches) {
+				t.Errorf("expected %d vulnerabilities in report, got %d", len(tc.matches), len(got.Report.Vulnerabilities))
+			}
+		})
+	}
+}
+
+// TestScan_StaleManifestTriggersFreshScan confirms canReuse returns false for
+// a stale manifest and the controller falls through to TriggerScan. We
+// install a fake k8s client whose Get always returns the stale manifest,
+// then short-circuit the test by cancelling the context once we observe the
+// scanner trigger — we don't try to drive the full poll loop here.
+func TestScan_StaleManifestTriggersFreshScan(t *testing.T) {
+	fixedNow := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	now = func() time.Time { return fixedNow }
+	t.Cleanup(func() { now = time.Now })
+
+	store := memory.NewStore()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	job := persistence.ScanJob{
+		ID: "job-stale",
+		Request: harbor.ScanRequest{
+			Registry: harbor.Registry{URL: "https://core.harbor.domain"},
+			Artifact: harbor.Artifact{
+				Repository: "library/nginx",
+				Digest:     "sha256:abcdef0123456789",
+			},
+		},
+		Status: persistence.Queued,
+	}
+	if err := store.Create(ctx, job); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	fakeK8s := &fakeK8sClient{
+		manifest: &k8s.VulnerabilityManifest{
+			Name:      "nginx-stale",
+			CreatedAt: fixedNow.Add(-30 * 24 * time.Hour), // 30 days old
+			Matches:   []k8s.VulnMatch{{ID: "CVE-2024-1111", Severity: "High"}},
+		},
+	}
+	// As soon as the controller calls TriggerScan we know it took the
+	// rescan path; cancel the context so the subsequent poll bails out
+	// instead of waiting for the 5s tick.
+	scanner := &triggerCancellingScanner{cancel: cancel}
+
+	c := NewController(store, scanner, fakeK8s, "kubescape", 24*time.Hour)
+	_ = c.Scan(ctx, job.ID) // expected to fail with context.Canceled after trigger
+
+	if scanner.triggers != 1 {
+		t.Errorf("scanner triggered %d time(s); stale manifest must trigger exactly one fresh scan", scanner.triggers)
+	}
+}
+
+type triggerCancellingScanner struct {
+	triggers int
+	cancel   context.CancelFunc
+}
+
+func (s *triggerCancellingScanner) TriggerScan(_ context.Context, _ harbor.ScanRequest) error {
+	s.triggers++
+	s.cancel()
+	return nil
 }


### PR DESCRIPTION
## Summary

Fixes #14 — the reuse gate \`existing != nil && len(existing.Matches) > 0\` baked in two real bugs:

1. **Clean images were rescanned every time** — zero matches → cache miss → wasted compute.
2. **Vulnerable manifests were reused with no freshness check** — newly disclosed CVEs against packages already present in a manifest would not surface until the manifest happened to be regenerated. Silent miss with security implications.

## The fix

Replace the match-count gate with a uniform TTL:

- New \`ScanConfig.ReuseTTL\` (env: \`SCAN_REUSE_TTL\`, default \`24h\`, set to \`0\` to disable reuse).
- \`canReuse(vm)\` returns true iff \`vm.CreatedAt\` is non-zero AND \`now - vm.CreatedAt < reuseTTL\`. Match count plays no role.
- Stale manifests log clearly and fall through to the existing \`TriggerScan\` path.
- Zero \`CreatedAt\` is treated as stale — we will not reuse a CRD of unknown age, since we can't tell whether it predates the current Grype DB.

## Tests

- \`TestCanReuse\` — direct unit table: fresh / stale / boundary / TTL=0 / negative TTL / zero CreatedAt.
- \`TestScan_FreshManifestIsReused\` — drives the controller end-to-end with a fake k8s client, asserts \`scanner.TriggerScan\` is NOT called for both a fresh non-clean manifest AND a fresh clean manifest. **Pins the symmetry fix.**
- \`TestScan_StaleManifestTriggersFreshScan\` — same harness with a 30-day-old manifest; asserts \`TriggerScan\` is called exactly once.

A \`now()\` indirection on \`time.Now\` lets tests use a fixed clock via \`t.Cleanup\`.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` passes including new tests.
- [ ] End-to-end: scan an image twice within 24h → second is reused; scan again with \`SCAN_REUSE_TTL=0\` → both are full scans.

## Why TTL rather than scanner-version match?

The canonical \`v1beta1.ToolMeta\` doesn't expose a DB version; we'd need a raw-JSON overlay (which we already use for CWEs) to recover one. TTL is simpler, defensible, and doesn't couple the adapter to scanner internals. Operators wanting strict-fresh behavior set \`SCAN_REUSE_TTL=0\`.