### PR TITLE
fix: bound in-memory store retention with a janitor (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ helm install harbor-scanner-kubescape ./charts/harbor-scanner-kubescape \
 | `KUBEVULN_URL` | `http://kubevuln:8080` | Base URL of the kubevuln service |
 | `KUBEVULN_NAMESPACE` | `kubescape` | Kubernetes namespace for Kubescape components |
 | `SCAN_REUSE_TTL` | `24h` | Freshness window for reusing an existing VulnerabilityManifest CRD. Older CRDs are treated as stale and trigger a fresh scan so newly disclosed CVEs are picked up. Set to `0` to disable reuse. |
+| `MEMORY_STORE_RETENTION` | `1h` | How long Finished/Failed scan jobs are kept in memory before eviction. Long enough to outlast Harbor's poll loop. Set to `0` to disable eviction (only sensible for tests). |
+| `MEMORY_STORE_CLEANUP_INTERVAL` | `5m` | How often the in-memory janitor runs. |
 
 ### TLS
 

--- a/cmd/scanner-kubescape/main.go
+++ b/cmd/scanner-kubescape/main.go
@@ -54,7 +54,16 @@ func run(ctx context.Context, cfg config.Config, buildInfo config.BuildInfo) err
 		slog.String("commit", buildInfo.Commit),
 	)
 
-	store := memory.NewStore()
+	store := memory.NewStore(
+		memory.WithRetention(cfg.Persistence.MemoryRetention),
+		memory.WithCleanupInterval(cfg.Persistence.MemoryCleanupInterval),
+	)
+	defer store.Close()
+	slog.Info("Memory store configured",
+		slog.Duration("retention", cfg.Persistence.MemoryRetention),
+		slog.Duration("cleanup_interval", cfg.Persistence.MemoryCleanupInterval),
+	)
+
 	scanner := scan.NewScanner(cfg.Kubevuln)
 
 	// Initialize K8s client for VulnerabilityManifest CRD access.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,9 +14,10 @@ type BuildInfo struct {
 
 // Config holds all configuration for the scanner adapter.
 type Config struct {
-	API      APIConfig
-	Kubevuln KubevulnConfig
-	Scan     ScanConfig
+	API         APIConfig
+	Kubevuln    KubevulnConfig
+	Scan        ScanConfig
+	Persistence PersistenceConfig
 }
 
 // ScanConfig holds policy knobs for the scan controller.
@@ -25,6 +26,17 @@ type ScanConfig struct {
 	// CRD. Anything older triggers a fresh scan so newly disclosed CVEs in
 	// the Grype DB get picked up. Zero disables reuse outright. See issue #14.
 	ReuseTTL time.Duration
+}
+
+// PersistenceConfig holds knobs for the in-memory persistence store. See
+// pkg/persistence/memory for behavior details. Issue #17.
+type PersistenceConfig struct {
+	// MemoryRetention is how long a Finished/Failed job is kept in memory
+	// before the janitor evicts it. Long enough to outlast Harbor's poll
+	// loop; short enough to bound memory.
+	MemoryRetention time.Duration
+	// MemoryCleanupInterval is how often the janitor runs.
+	MemoryCleanupInterval time.Duration
 }
 
 // APIConfig holds HTTP server configuration.
@@ -70,6 +82,10 @@ func Load() (Config, error) {
 		Scan: ScanConfig{
 			ReuseTTL: durationFromEnv("SCAN_REUSE_TTL", 24*time.Hour),
 		},
+		Persistence: PersistenceConfig{
+			MemoryRetention:       durationFromEnv("MEMORY_STORE_RETENTION", 1*time.Hour),
+			MemoryCleanupInterval: durationFromEnv("MEMORY_STORE_CLEANUP_INTERVAL", 5*time.Minute),
+		},
 	}
 
 	return cfg, nil
@@ -77,7 +93,7 @@ func Load() (Config, error) {
 
 // durationFromEnv reads a Go duration from the named env var, falling back to
 // the provided default if unset or unparseable. Examples: "1h", "30m", "0s".
-// "0" or any non-positive duration disables the relevant feature.
+// A non-positive duration disables the relevant feature.
 func durationFromEnv(key string, defaultValue time.Duration) time.Duration {
 	v := os.Getenv(key)
 	if v == "" {

--- a/pkg/persistence/memory/store.go
+++ b/pkg/persistence/memory/store.go
@@ -1,31 +1,96 @@
+// Package memory provides an in-process implementation of persistence.Store.
+//
+// Single-instance only: state is not shared across pods, and any restart
+// loses all state (issue #15). For a durable production backend, use a
+// shared store (e.g. Redis). This implementation is appropriate for local
+// development and the single-replica chart deployment.
+//
+// The store enforces bounded retention of terminal jobs (Finished/Failed)
+// via a janitor goroutine — once a job has been in a terminal state for
+// longer than the configured retention window, it is evicted. Without this
+// the map would grow unboundedly with scan volume (issue #17). Non-terminal
+// jobs are never evicted; the janitor leaves them alone until they reach a
+// terminal state.
 package memory
 
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/harbor"
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/persistence"
 )
 
-// Store is an in-memory implementation of persistence.Store.
-//
-// Single-instance only. Scan state is not shared across pods, so any
-// multi-replica deployment will return 404 on Harbor poll requests that land
-// on a replica different from the one that accepted the scan. The Helm chart
-// fails installation when replicaCount > 1 unless explicitly overridden — see
-// https://github.com/goharbor/harbor-scanner-kubescape/issues/2 for the
-// shared-backend (Redis/etc.) plan.
+const (
+	// DefaultRetention is the time a Finished or Failed job is kept before
+	// the janitor evicts it. Long enough for Harbor to complete its poll
+	// loop after the scan finishes, short enough to bound memory.
+	DefaultRetention = 1 * time.Hour
+	// DefaultCleanupInterval is how often the janitor runs.
+	DefaultCleanupInterval = 5 * time.Minute
+)
+
+// Store is an in-memory persistence.Store. See package doc for caveats.
 type Store struct {
-	mu   sync.RWMutex
-	jobs map[string]*persistence.ScanJob
+	mu              sync.RWMutex
+	jobs            map[string]*persistence.ScanJob
+	retention       time.Duration
+	cleanupInterval time.Duration
+	now             func() time.Time
+	stop            chan struct{}
+	stopOnce        sync.Once
+	stopped         chan struct{}
 }
 
-func NewStore() *Store {
-	return &Store{
-		jobs: make(map[string]*persistence.ScanJob),
+// Option configures a Store.
+type Option func(*Store)
+
+// WithRetention overrides the terminal-job retention window. A zero or
+// negative value disables eviction (jobs are kept forever — only useful for
+// short-lived tests, never for production).
+func WithRetention(d time.Duration) Option {
+	return func(s *Store) { s.retention = d }
+}
+
+// WithCleanupInterval overrides how often the janitor runs.
+func WithCleanupInterval(d time.Duration) Option {
+	return func(s *Store) { s.cleanupInterval = d }
+}
+
+// WithNow overrides the clock. Tests inject a fixed time.
+func WithNow(f func() time.Time) Option {
+	return func(s *Store) { s.now = f }
+}
+
+// NewStore creates a Store and starts its janitor goroutine. Call Close()
+// on shutdown to stop the janitor cleanly. Safe defaults are applied when
+// no options are provided.
+func NewStore(opts ...Option) *Store {
+	s := &Store{
+		jobs:            make(map[string]*persistence.ScanJob),
+		retention:       DefaultRetention,
+		cleanupInterval: DefaultCleanupInterval,
+		now:             time.Now,
+		stop:            make(chan struct{}),
+		stopped:         make(chan struct{}),
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	go s.janitor()
+	return s
+}
+
+// Close stops the janitor goroutine. Safe to call multiple times.
+func (s *Store) Close() {
+	s.stopOnce.Do(func() {
+		close(s.stop)
+		<-s.stopped
+	})
 }
 
 func (s *Store) Create(_ context.Context, job persistence.ScanJob) error {
@@ -58,6 +123,9 @@ func (s *Store) UpdateStatus(_ context.Context, id string, status persistence.Sc
 	if len(errMsg) > 0 {
 		job.Error = errMsg[0]
 	}
+	if status == persistence.Finished || status == persistence.Failed {
+		job.TerminalAt = s.now()
+	}
 	return nil
 }
 
@@ -70,4 +138,61 @@ func (s *Store) UpdateReport(_ context.Context, id string, report harbor.ScanRep
 	}
 	job.Report = report
 	return nil
+}
+
+// Len returns the current number of jobs in the store. Useful for tests
+// asserting eviction; not part of any public interface.
+func (s *Store) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.jobs)
+}
+
+// Cleanup runs one eviction pass, deleting terminal jobs whose TerminalAt
+// is older than retention. Returns the number of jobs evicted. Exported so
+// tests can drive cleanup deterministically without waiting for the ticker.
+func (s *Store) Cleanup() int {
+	if s.retention <= 0 {
+		return 0
+	}
+	cutoff := s.now().Add(-s.retention)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	evicted := 0
+	for id, job := range s.jobs {
+		if job.TerminalAt.IsZero() {
+			continue
+		}
+		if job.TerminalAt.Before(cutoff) {
+			delete(s.jobs, id)
+			evicted++
+		}
+	}
+	return evicted
+}
+
+func (s *Store) janitor() {
+	defer close(s.stopped)
+	if s.retention <= 0 || s.cleanupInterval <= 0 {
+		// Eviction disabled. Wait for Close so the channel still closes
+		// cleanly, but do nothing in the meantime.
+		<-s.stop
+		return
+	}
+
+	ticker := time.NewTicker(s.cleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-ticker.C:
+			if n := s.Cleanup(); n > 0 {
+				slog.Debug("Memory store eviction", slog.Int("evicted", n), slog.Int("remaining", s.Len()))
+			}
+		}
+	}
 }

--- a/pkg/persistence/memory/store_test.go
+++ b/pkg/persistence/memory/store_test.go
@@ -1,0 +1,155 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/goharbor/harbor-scanner-kubescape/pkg/persistence"
+)
+
+// TestCleanup_EvictsTerminalJobsPastRetention pins issue #17: terminal jobs
+// older than the retention window must be evicted by the janitor; non-terminal
+// jobs and fresh terminal jobs must be preserved.
+func TestCleanup_EvictsTerminalJobsPastRetention(t *testing.T) {
+	fixedNow := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return fixedNow }
+
+	s := NewStore(
+		WithRetention(1*time.Hour),
+		WithCleanupInterval(time.Hour), // long; we drive Cleanup() manually
+		WithNow(clock),
+	)
+	defer s.Close()
+
+	ctx := context.Background()
+
+	// Three jobs: stale-finished, fresh-finished, in-progress.
+	mustCreate(t, s, "stale-finished")
+	mustCreate(t, s, "fresh-finished")
+	mustCreate(t, s, "in-progress")
+
+	// Stale terminal — TerminalAt set to 2h ago, well past 1h retention.
+	clock = func() time.Time { return fixedNow.Add(-2 * time.Hour) }
+	s.now = clock
+	if err := s.UpdateStatus(ctx, "stale-finished", persistence.Finished); err != nil {
+		t.Fatalf("UpdateStatus stale: %v", err)
+	}
+
+	// Fresh terminal — TerminalAt set "now-1m", well within retention.
+	clock = func() time.Time { return fixedNow.Add(-1 * time.Minute) }
+	s.now = clock
+	if err := s.UpdateStatus(ctx, "fresh-finished", persistence.Failed, "transient error"); err != nil {
+		t.Fatalf("UpdateStatus fresh: %v", err)
+	}
+
+	// in-progress is left as Queued (no UpdateStatus call) so TerminalAt is zero.
+
+	// Restore the clock to "now" for the eviction pass.
+	clock = func() time.Time { return fixedNow }
+	s.now = clock
+
+	if want, got := 3, s.Len(); got != want {
+		t.Fatalf("seed expected %d jobs, got %d", want, got)
+	}
+
+	evicted := s.Cleanup()
+	if evicted != 1 {
+		t.Errorf("expected 1 eviction, got %d", evicted)
+	}
+
+	// Stale-finished is gone; the others remain.
+	if got, _ := s.Get(ctx, "stale-finished"); got != nil {
+		t.Errorf("stale-finished should have been evicted, got %+v", got)
+	}
+	if got, _ := s.Get(ctx, "fresh-finished"); got == nil {
+		t.Errorf("fresh-finished should still be present")
+	}
+	if got, _ := s.Get(ctx, "in-progress"); got == nil {
+		t.Errorf("in-progress should still be present (TerminalAt is zero)")
+	}
+}
+
+// TestUpdateStatus_SetsTerminalAt confirms the timestamp is set on Finished
+// and Failed transitions but stays zero for non-terminal transitions.
+func TestUpdateStatus_SetsTerminalAt(t *testing.T) {
+	fixedNow := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	s := NewStore(WithNow(func() time.Time { return fixedNow }))
+	defer s.Close()
+	ctx := context.Background()
+
+	mustCreate(t, s, "job1")
+	mustCreate(t, s, "job2")
+	mustCreate(t, s, "job3")
+
+	if err := s.UpdateStatus(ctx, "job1", persistence.Pending); err != nil {
+		t.Fatalf("Pending: %v", err)
+	}
+	got, _ := s.Get(ctx, "job1")
+	if !got.TerminalAt.IsZero() {
+		t.Errorf("Pending must not set TerminalAt, got %v", got.TerminalAt)
+	}
+
+	if err := s.UpdateStatus(ctx, "job2", persistence.Finished); err != nil {
+		t.Fatalf("Finished: %v", err)
+	}
+	got, _ = s.Get(ctx, "job2")
+	if !got.TerminalAt.Equal(fixedNow) {
+		t.Errorf("Finished must set TerminalAt to fixedNow, got %v", got.TerminalAt)
+	}
+
+	if err := s.UpdateStatus(ctx, "job3", persistence.Failed, "boom"); err != nil {
+		t.Fatalf("Failed: %v", err)
+	}
+	got, _ = s.Get(ctx, "job3")
+	if !got.TerminalAt.Equal(fixedNow) {
+		t.Errorf("Failed must set TerminalAt to fixedNow, got %v", got.TerminalAt)
+	}
+	if got.Error != "boom" {
+		t.Errorf("Failed must propagate error message, got %q", got.Error)
+	}
+}
+
+// TestCleanup_DisabledByZeroRetention confirms a zero/negative retention
+// disables eviction entirely (useful for tests; never for prod).
+func TestCleanup_DisabledByZeroRetention(t *testing.T) {
+	fixedNow := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	s := NewStore(
+		WithRetention(0),
+		WithCleanupInterval(time.Hour),
+		WithNow(func() time.Time { return fixedNow }),
+	)
+	defer s.Close()
+	ctx := context.Background()
+
+	mustCreate(t, s, "ancient")
+	// Use a separate clock helper to set TerminalAt to deep past.
+	s.mu.Lock()
+	s.jobs["ancient"].Status = persistence.Finished
+	s.jobs["ancient"].TerminalAt = fixedNow.Add(-10000 * time.Hour)
+	s.mu.Unlock()
+
+	if n := s.Cleanup(); n != 0 {
+		t.Errorf("Cleanup with retention=0 must evict nothing, got %d evicted", n)
+	}
+	if got, _ := s.Get(ctx, "ancient"); got == nil {
+		t.Error("job should still be present when retention is disabled")
+	}
+}
+
+// TestClose_StopsJanitor ensures Close() returns and is idempotent.
+func TestClose_StopsJanitor(t *testing.T) {
+	s := NewStore(
+		WithRetention(time.Hour),
+		WithCleanupInterval(10*time.Millisecond),
+	)
+	s.Close()
+	s.Close() // safe to call again
+}
+
+func mustCreate(t *testing.T, s *Store, id string) {
+	t.Helper()
+	if err := s.Create(context.Background(), persistence.ScanJob{ID: id, Status: persistence.Queued}); err != nil {
+		t.Fatalf("seed %s: %v", id, err)
+	}
+}

--- a/pkg/persistence/store.go
+++ b/pkg/persistence/store.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"time"
 
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/harbor"
 )
@@ -32,12 +33,18 @@ func (s ScanJobStatus) String() string {
 }
 
 // ScanJob represents a scan job with its status and result.
+//
+// TerminalAt is set when Status transitions to Finished or Failed. Stores
+// that retain finished/failed jobs for a bounded window (e.g. the in-memory
+// store) use this timestamp to decide when to evict an entry. A zero
+// TerminalAt means the job has not yet reached a terminal state.
 type ScanJob struct {
-	ID      string
-	Request harbor.ScanRequest
-	Status  ScanJobStatus
-	Report  harbor.ScanReport
-	Error   string
+	ID         string
+	Request    harbor.ScanRequest
+	Status     ScanJobStatus
+	Report     harbor.ScanReport
+	Error      string
+	TerminalAt time.Time
 }
 
 // Store provides persistence for scan jobs.


### PR DESCRIPTION
## Summary

Fixes #17 — \`pkg/persistence/memory/store.go\` had no eviction. Every \`Finished\` and \`Failed\` job stayed in the map for the lifetime of the process, so memory grew linearly with scan volume. A long-running adapter with steady traffic would OOM.

## Approach

Bounded retention behind the existing Store interface:

- \`persistence.ScanJob\` gains a \`TerminalAt\` timestamp. \`UpdateStatus\` sets it when status transitions to \`Finished\` or \`Failed\`. Non-terminal jobs leave it zero and are never eligible for eviction.
- \`memory.NewStore\` is options-driven: \`WithRetention\`, \`WithCleanupInterval\`, \`WithNow\`. Defaults (1h retention, 5min interval) are tuned to outlast Harbor's poll loop while still bounding memory.
- A janitor goroutine periodically calls \`Cleanup()\`, which evicts terminal jobs whose \`TerminalAt\` is older than the retention cutoff. \`Cleanup()\` is exported so tests can drive eviction deterministically.
- \`Close()\` stops the janitor cleanly; \`main.go\` defers it.
- New env vars \`MEMORY_STORE_RETENTION\` (default \`1h\`) and \`MEMORY_STORE_CLEANUP_INTERVAL\` (default \`5m\`). Set retention to \`0\` to disable eviction.

## Tests

\`pkg/persistence/memory/store_test.go\`:

- **TestCleanup_EvictsTerminalJobsPastRetention** — three jobs (stale terminal, fresh terminal, in-progress); only the stale terminal is evicted. The in-progress job with zero \`TerminalAt\` is preserved.
- **TestUpdateStatus_SetsTerminalAt** — Pending leaves \`TerminalAt\` zero; Finished and Failed set it to \`now()\`. Failed also propagates the error message.
- **TestCleanup_DisabledByZeroRetention** — \`retention=0\` evicts nothing even for ancient terminal jobs.
- **TestClose_StopsJanitor** — Close is idempotent.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` passes including new tests.
- [ ] Long-running smoke: leave the adapter up under steady scan load; assert memory stays bounded.

## Relation to #15

This is the interim fix. Once a durable backend lands (#15), the in-memory store remains as the dev default and Redis handles retention via \`EXPIRE\`. The Store-interface shape here doesn't constrain that work — \`TerminalAt\` is a useful field for a Redis impl too if it serializes \`ScanJob\`.