### PR TITLE
fix: ignore stale VulnerabilityManifest during post-rescan poll (#23)

### DIFF
--- a/pkg/scan/controller.go
+++ b/pkg/scan/controller.go
@@ -11,11 +11,17 @@ import (
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/persistence"
 )
 
-const (
-	// How often to poll for VulnerabilityManifest CRD after triggering a scan.
+// pollInterval and pollTimeout are vars (not consts) so tests can shorten
+// them via t.Cleanup. Production always uses the defaults.
+var (
+	// pollInterval is how often to poll for VulnerabilityManifest CRD after
+	// triggering a scan.
 	pollInterval = 5 * time.Second
-	// Maximum time to wait for a scan to complete.
+	// pollTimeout is the maximum time to wait for a scan to complete.
 	pollTimeout = 10 * time.Minute
+)
+
+const (
 	// DefaultReuseTTL is the default freshness window for reusing an existing
 	// VulnerabilityManifest. Anything older triggers a fresh scan so newly
 	// disclosed CVEs in the Grype DB get picked up. See issue #14.
@@ -115,6 +121,14 @@ func (c *controller) scan(ctx context.Context, scanJobID string) error {
 	// rescanned every time, and vulnerable manifests were reused forever
 	// even after the Grype DB or scanner version changed (issue #14).
 	existing, err := c.k8sClient.GetVulnerabilityManifest(ctx, c.namespace, crdName)
+
+	// staleSeenAt is the CreatedAt of any existing-but-stale CRD we observed
+	// before triggering the rescan. The poll loop only accepts manifests with
+	// CreatedAt strictly newer than this — otherwise it would happily return
+	// the same stale CRD it just rejected on the very next tick, before
+	// kubevuln has had a chance to overwrite it. See issue #23.
+	var staleSeenAt time.Time
+
 	if err != nil {
 		slog.Warn("Failed to check existing VulnerabilityManifest, will trigger new scan",
 			slog.String("err", err.Error()),
@@ -132,6 +146,7 @@ func (c *controller) scan(ctx context.Context, scanJobID string) error {
 		}
 		return c.store.UpdateStatus(ctx, scanJobID, persistence.Finished)
 	} else if existing != nil {
+		staleSeenAt = existing.CreatedAt
 		slog.Info("Existing VulnerabilityManifest is stale, triggering fresh scan",
 			slog.String("crd_name", crdName),
 			slog.Time("created_at", existing.CreatedAt),
@@ -149,8 +164,10 @@ func (c *controller) scan(ctx context.Context, scanJobID string) error {
 		return fmt.Errorf("triggering kubevuln scan: %w", err)
 	}
 
-	// Step 3: Poll for VulnerabilityManifest CRD
-	report, err := c.pollForResults(ctx, crdName, job.Request.Artifact)
+	// Step 3: Poll for VulnerabilityManifest CRD. Pass staleSeenAt so the
+	// loop ignores any CRD with CreatedAt <= staleSeenAt — i.e. the very
+	// stale object we just rejected, which kubevuln has not yet overwritten.
+	report, err := c.pollForResults(ctx, crdName, job.Request.Artifact, staleSeenAt)
 	if err != nil {
 		return fmt.Errorf("waiting for scan results: %w", err)
 	}
@@ -181,9 +198,16 @@ func (c *controller) canReuse(vm *k8s.VulnerabilityManifest) bool {
 }
 
 // pollForResults polls the Kubernetes API for the VulnerabilityManifest CRD
-// until it appears with results or the timeout is reached.
-func (c *controller) pollForResults(ctx context.Context, crdName string, artifact harbor.Artifact) (harbor.ScanReport, error) {
-	deadline := time.Now().Add(pollTimeout)
+// until a manifest strictly newer than staleSeenAt appears, or the timeout
+// is reached.
+//
+// staleSeenAt is the CreatedAt of any pre-existing stale CRD the controller
+// already rejected as too old (zero if no prior CRD existed). Without this
+// gate, the very first poll tick after triggering a rescan would return the
+// same stale object kubevuln has not yet overwritten — defeating the
+// freshness check. See issue #23.
+func (c *controller) pollForResults(ctx context.Context, crdName string, artifact harbor.Artifact, staleSeenAt time.Time) (harbor.ScanReport, error) {
+	deadline := now().Add(pollTimeout)
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
@@ -192,7 +216,7 @@ func (c *controller) pollForResults(ctx context.Context, crdName string, artifac
 		case <-ctx.Done():
 			return harbor.ScanReport{}, ctx.Err()
 		case <-ticker.C:
-			if time.Now().After(deadline) {
+			if now().After(deadline) {
 				return harbor.ScanReport{}, fmt.Errorf("timed out waiting for VulnerabilityManifest %s after %v", crdName, pollTimeout)
 			}
 
@@ -205,17 +229,35 @@ func (c *controller) pollForResults(ctx context.Context, crdName string, artifac
 				continue
 			}
 
-			if vm != nil {
-				slog.Info("VulnerabilityManifest found",
+			if vm == nil {
+				slog.Debug("VulnerabilityManifest not yet available, retrying",
 					slog.String("crd_name", crdName),
-					slog.Int("matches", len(vm.Matches)),
 				)
-				return TransformManifestToReport(vm, artifact), nil
+				continue
 			}
 
-			slog.Debug("VulnerabilityManifest not yet available, retrying",
+			if !staleSeenAt.IsZero() && !vm.CreatedAt.After(staleSeenAt) {
+				slog.Debug("Polled VulnerabilityManifest is the stale one, waiting for kubevuln to overwrite",
+					slog.String("crd_name", crdName),
+					slog.Time("created_at", vm.CreatedAt),
+					slog.Time("stale_seen_at", staleSeenAt),
+				)
+				continue
+			}
+
+			if vm.CreatedAt.IsZero() {
+				slog.Warn("Polled VulnerabilityManifest has zero CreatedAt, treating as not-yet-ready",
+					slog.String("crd_name", crdName),
+				)
+				continue
+			}
+
+			slog.Info("VulnerabilityManifest found",
 				slog.String("crd_name", crdName),
+				slog.Int("matches", len(vm.Matches)),
+				slog.Time("created_at", vm.CreatedAt),
 			)
+			return TransformManifestToReport(vm, artifact), nil
 		}
 	}
 }

--- a/pkg/scan/controller_test.go
+++ b/pkg/scan/controller_test.go
@@ -13,14 +13,21 @@ import (
 )
 
 // fakeK8sClient is a minimal in-memory k8s.Client for testing the controller.
-// GetVulnerabilityManifest returns the seeded manifest (or nil to simulate not
-// found). TriggerCount is incremented every time the controller asks the
-// scanner to run, which lets tests assert reuse vs rescan decisions.
+// GetVulnerabilityManifest returns the current `manifest` field. Tests that
+// need the response to change over time can use `getHook` — when set, it is
+// invoked on every Get and may mutate `manifest` to simulate kubevuln
+// asynchronously overwriting the CRD between polls.
 type fakeK8sClient struct {
 	manifest *k8s.VulnerabilityManifest
+	getCalls int
+	getHook  func(callIdx int, f *fakeK8sClient)
 }
 
 func (f *fakeK8sClient) GetVulnerabilityManifest(_ context.Context, _, _ string) (*k8s.VulnerabilityManifest, error) {
+	f.getCalls++
+	if f.getHook != nil {
+		f.getHook(f.getCalls, f)
+	}
 	return f.manifest, nil
 }
 
@@ -284,4 +291,119 @@ func (s *triggerCancellingScanner) TriggerScan(_ context.Context, _ harbor.ScanR
 	s.triggers++
 	s.cancel()
 	return nil
+}
+
+// TestScan_StaleManifestNotReturnedByPoll pins issue #23: after the
+// controller decides an existing CRD is stale and triggers a rescan, the
+// poll loop must NOT immediately accept that same stale CRD on the next
+// tick. It must wait until kubevuln overwrites it with a strictly-newer
+// CreatedAt.
+//
+// We drive the test with a stateful fake k8s client. Calls 1 (initial
+// check) and 2 (first poll tick) return the stale CRD. On call 3, the
+// fake mutates its state to simulate kubevuln finishing the scan: the
+// manifest now has a fresh CreatedAt. The test asserts the final report
+// reflects the fresh data, NOT the stale one.
+func TestScan_StaleManifestNotReturnedByPoll(t *testing.T) {
+	fixedNow := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	now = func() time.Time { return fixedNow }
+	t.Cleanup(func() { now = time.Now })
+
+	// Shorten the poll interval so the test finishes quickly.
+	pollInterval = 5 * time.Millisecond
+	t.Cleanup(func() { pollInterval = 5 * time.Second })
+
+	staleCRD := &k8s.VulnerabilityManifest{
+		Name:      "nginx",
+		CreatedAt: fixedNow.Add(-30 * 24 * time.Hour),
+		Matches:   []k8s.VulnMatch{{ID: "CVE-2024-OLD", Severity: "Low"}},
+	}
+	freshCRD := &k8s.VulnerabilityManifest{
+		Name:      "nginx",
+		CreatedAt: fixedNow,
+		Matches: []k8s.VulnMatch{
+			{ID: "CVE-2024-NEW", Severity: "Critical"},
+		},
+	}
+
+	fakeK8s := &fakeK8sClient{
+		manifest: staleCRD,
+		// On the third Get (initial-check + one stale-poll + this one),
+		// simulate kubevuln overwriting the CRD with the fresh version.
+		getHook: func(callIdx int, f *fakeK8sClient) {
+			if callIdx >= 3 {
+				f.manifest = freshCRD
+			}
+		},
+	}
+	scanner := &fakeScanner{}
+
+	store := memory.NewStore()
+	ctx := context.Background()
+
+	job := persistence.ScanJob{
+		ID: "job-stale-poll",
+		Request: harbor.ScanRequest{
+			Registry: harbor.Registry{URL: "https://core.harbor.domain"},
+			Artifact: harbor.Artifact{
+				Repository: "library/nginx",
+				Digest:     "sha256:abcdef0123456789",
+			},
+		},
+		Status: persistence.Queued,
+	}
+	if err := store.Create(ctx, job); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	c := NewController(store, scanner, fakeK8s, "kubescape", 24*time.Hour)
+	if err := c.Scan(ctx, job.ID); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	if scanner.triggers != 1 {
+		t.Errorf("scanner.triggers = %d, want 1 (stale CRD must trigger exactly one rescan)", scanner.triggers)
+	}
+
+	got, _ := store.Get(ctx, job.ID)
+	if got.Status != persistence.Finished {
+		t.Fatalf("expected status Finished, got %s (job.Error=%q)", got.Status, got.Error)
+	}
+	if len(got.Report.Vulnerabilities) != 1 {
+		t.Fatalf("expected 1 vulnerability in report, got %d", len(got.Report.Vulnerabilities))
+	}
+	if got.Report.Vulnerabilities[0].ID != "CVE-2024-NEW" {
+		t.Errorf("report contains stale data: got %q, want CVE-2024-NEW. The poll loop accepted the rejected stale CRD instead of waiting for kubevuln to overwrite.",
+			got.Report.Vulnerabilities[0].ID)
+	}
+	// We expect at least 3 Get calls: initial check + at least one stale poll + the fresh one.
+	if fakeK8s.getCalls < 3 {
+		t.Errorf("expected at least 3 Get calls (init + stale poll + fresh), got %d", fakeK8s.getCalls)
+	}
+}
+
+// TestPollForResults_ZeroStaleSeenAt confirms that when there is no prior
+// stale CRD (staleSeenAt is zero), any non-nil manifest with a non-zero
+// CreatedAt is accepted on the first tick — i.e. we don't break the
+// fresh-scan path while fixing the stale-rescan path.
+func TestPollForResults_ZeroStaleSeenAt(t *testing.T) {
+	pollInterval = 5 * time.Millisecond
+	t.Cleanup(func() { pollInterval = 5 * time.Second })
+
+	freshCRD := &k8s.VulnerabilityManifest{
+		Name:      "nginx",
+		CreatedAt: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		Matches:   []k8s.VulnMatch{{ID: "CVE-2024-NEW", Severity: "High"}},
+	}
+
+	fakeK8s := &fakeK8sClient{manifest: freshCRD}
+	c := &controller{k8sClient: fakeK8s, namespace: "kubescape"}
+
+	report, err := c.pollForResults(context.Background(), "nginx", harbor.Artifact{}, time.Time{})
+	if err != nil {
+		t.Fatalf("pollForResults: %v", err)
+	}
+	if len(report.Vulnerabilities) != 1 || report.Vulnerabilities[0].ID != "CVE-2024-NEW" {
+		t.Errorf("expected fresh CVE-2024-NEW in report, got %+v", report.Vulnerabilities)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #23 — \`canReuse\` correctly rejected an over-old CRD on the initial check, but the poll loop then accepted the **very same stale object** on the next 5-second tick (because kubevuln hadn't overwritten it yet). The newly disclosed CVEs the rescan was meant to surface got silently skipped.

## Approach

Capture the stale CRD's \`CreatedAt\` at the rejection site, thread it into \`pollForResults\` as \`staleSeenAt\`, and only accept manifests whose \`CreatedAt\` is **strictly newer**. A zero \`CreatedAt\` on the polled CRD is also treated as not-yet-ready, to avoid a race where kubevuln writes the object header before the body.

## Other small touches

- Switch \`pollForResults\`'s remaining \`time.Now()\` calls to the testable \`now()\` so the whole controller is on one clock.
- Promote \`pollInterval\` and \`pollTimeout\` from \`const\` to package-private \`var\` so tests can shorten them via \`t.Cleanup\` instead of waiting 5s+ per tick.

## Tests

- **\`TestScan_StaleManifestNotReturnedByPoll\`** — stateful fake k8s client returns the stale CRD on calls 1-2 (initial check + first poll), then mutates to the fresh CRD on call 3, simulating kubevuln finishing the rescan. Asserts the final report contains the fresh \`CVE-2024-NEW\`, not the stale \`CVE-2024-OLD\`. **Would have failed under the previous code.**
- **\`TestPollForResults_ZeroStaleSeenAt\`** — confirms the no-prior-CRD path is unchanged: first non-nil manifest with non-zero \`CreatedAt\` is accepted.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` passes including the new tests.
- [ ] End-to-end: with a 30-day-old CRD in the cluster, request a scan. Verify the response reflects the rescan output, not the old CRD.