### PR TITLE
fix: cancel in-flight scans on graceful shutdown (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,21 @@ helm install harbor-scanner-kubescape ./charts/harbor-scanner-kubescape \
   --set service.port=8443
 ```
 
+### Graceful shutdown
+
+On `SIGTERM` (rolling restart, scale-down) the adapter:
+
+1. Stops accepting new HTTP requests and drains in-flight ones (10s budget).
+2. Cancels the parent context shared by all async scan goroutines so their
+   poll loops return promptly with `context.Canceled`.
+3. Waits up to 10s for those goroutines to record `Failed("interrupted by
+   pod shutdown")` in the store, so Harbor sees a clean 500 instead of
+   indefinite 302s. See [#24](https://github.com/goharbor/harbor-scanner-kubescape/issues/24).
+
+Ungraceful crashes (OOM, kernel kill) bypass step 3, so jobs they were
+running can stay `Pending` until they expire via `MEMORY_STORE_RETENTION`
+or `REDIS_JOB_TTL`. Lower the TTL if you want faster orphan cleanup.
+
 ### Persistence and replicas
 
 The adapter ships with two persistence backends:

--- a/cmd/scanner-kubescape/main.go
+++ b/cmd/scanner-kubescape/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -112,7 +113,16 @@ func run(ctx context.Context, cfg config.Config, buildInfo config.BuildInfo) err
 		},
 	}
 
-	handler := v1.NewAPIHandler(buildInfo, cfg, store, controller, readiness...)
+	// scanCtx is the parent for every async scan goroutine. Cancelling it
+	// during shutdown propagates ctx.Done into the controller's poll loop,
+	// which returns ctx.Err and lets the wrapper Scan() record Failed
+	// status in the store before the goroutine exits — instead of leaving
+	// the job Pending until Redis TTL expiry. See issue #24.
+	scanCtx, cancelScans := context.WithCancel(context.Background())
+	defer cancelScans()
+	var scanWG sync.WaitGroup
+
+	handler := v1.NewAPIHandler(buildInfo, cfg, store, controller, scanCtx, &scanWG, readiness...)
 
 	srv := &http.Server{
 		Addr:         cfg.API.Addr,
@@ -122,6 +132,11 @@ func run(ctx context.Context, cfg config.Config, buildInfo config.BuildInfo) err
 		IdleTimeout:  60 * time.Second,
 	}
 
+	const (
+		httpShutdownTimeout = 10 * time.Second
+		scanShutdownTimeout = 10 * time.Second
+	)
+
 	shutdownComplete := make(chan struct{})
 	go func() {
 		sigint := make(chan os.Signal, 1)
@@ -129,12 +144,32 @@ func run(ctx context.Context, cfg config.Config, buildInfo config.BuildInfo) err
 		captured := <-sigint
 		slog.Info("Received signal, shutting down", slog.String("signal", captured.String()))
 
-		shutdownCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cancel()
-
-		if err := srv.Shutdown(shutdownCtx); err != nil {
+		// Step 1: stop accepting new HTTP requests and drain in-flight ones.
+		httpCtx, cancelHTTP := context.WithTimeout(ctx, httpShutdownTimeout)
+		defer cancelHTTP()
+		if err := srv.Shutdown(httpCtx); err != nil {
 			slog.Error("Server shutdown error", slog.String("err", err.Error()))
 		}
+
+		// Step 2: cancel async scan goroutines and wait briefly for them to
+		// record Failed("interrupted") in the store. Ungraceful crashes
+		// that bypass this path will leak Pending jobs until their TTL
+		// expires (REDIS_JOB_TTL or MEMORY_STORE_RETENTION).
+		cancelScans()
+		scansDone := make(chan struct{})
+		go func() {
+			scanWG.Wait()
+			close(scansDone)
+		}()
+		select {
+		case <-scansDone:
+			slog.Info("All in-flight scans recorded a terminal state")
+		case <-time.After(scanShutdownTimeout):
+			slog.Warn("Timed out waiting for in-flight scans to finalize; some jobs may stay Pending until TTL expiry",
+				slog.Duration("timeout", scanShutdownTimeout),
+			)
+		}
+
 		close(shutdownComplete)
 	}()
 

--- a/pkg/http/api/v1/handler.go
+++ b/pkg/http/api/v1/handler.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"sync"
 
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/config"
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/harbor"
@@ -44,6 +45,18 @@ type requestHandler struct {
 	store           persistence.Store
 	controller      scan.Controller
 	readinessChecks []ReadinessCheck
+
+	// scanCtx is the parent context inherited by every async scan goroutine.
+	// When cancelled (typically on SIGTERM), the goroutines see ctx.Done in
+	// pollForResults and the controller's wrapper records the job as Failed
+	// instead of leaving it Pending until TTL expiry. See issue #24. May be
+	// nil — falls back to context.Background() with no cancellation.
+	scanCtx context.Context
+
+	// scanWG counts in-flight scan goroutines so the shutdown path can wait
+	// for them to record Failed status before the process exits. May be nil
+	// in tests that don't care about graceful shutdown.
+	scanWG *sync.WaitGroup
 }
 
 // NewAPIHandler creates the HTTP handler with all Harbor Scanner API routes.
@@ -52,19 +65,32 @@ type requestHandler struct {
 // returns an error the probe responds 503 with a JSON listing the failing
 // subsystems, otherwise 200. /probe/healthy stays 200 unconditionally —
 // liveness reflects the process being up, not its ability to serve.
+//
+// scanCtx and scanWG (both may be nil) plumb a process-lifetime cancellable
+// context and an in-flight counter into async scan goroutines. main.go
+// passes a real ctx + wg so SIGTERM can cancel running scans and wait for
+// them to record Failed status; tests typically pass nil for both. See
+// issue #24.
 func NewAPIHandler(
 	buildInfo config.BuildInfo,
 	cfg config.Config,
 	store persistence.Store,
 	controller scan.Controller,
+	scanCtx context.Context,
+	scanWG *sync.WaitGroup,
 	readinessChecks ...ReadinessCheck,
 ) http.Handler {
+	if scanCtx == nil {
+		scanCtx = context.Background()
+	}
 	h := &requestHandler{
 		buildInfo:       buildInfo,
 		config:          cfg,
 		store:           store,
 		controller:      controller,
 		readinessChecks: readinessChecks,
+		scanCtx:         scanCtx,
+		scanWG:          scanWG,
 	}
 
 	router := mux.NewRouter()
@@ -154,12 +180,21 @@ func (h *requestHandler) AcceptScanRequest(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Launch scan asynchronously.
-	// Use a detached context because r.Context() is cancelled when the HTTP response is sent.
+	// Launch scan asynchronously. The goroutine inherits h.scanCtx (NOT
+	// r.Context(), which is cancelled when the HTTP response is sent) so
+	// that on SIGTERM the controller's poll loop sees ctx.Done, returns
+	// ctx.Err, and the wrapper Scan() writes Failed("interrupted") to the
+	// store rather than leaving the job Pending until TTL expiry.
+	// See issue #24.
 	if h.controller != nil {
+		if h.scanWG != nil {
+			h.scanWG.Add(1)
+		}
 		go func() {
-			scanCtx := context.Background()
-			if err := h.controller.Scan(scanCtx, scanJobID); err != nil {
+			if h.scanWG != nil {
+				defer h.scanWG.Done()
+			}
+			if err := h.controller.Scan(h.scanCtx, scanJobID); err != nil {
 				slog.Error("Async scan failed",
 					slog.String("scan_job_id", scanJobID),
 					slog.String("err", err.Error()),

--- a/pkg/http/api/v1/handler_test.go
+++ b/pkg/http/api/v1/handler_test.go
@@ -2,11 +2,14 @@ package v1
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/config"
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/harbor"
@@ -21,6 +24,8 @@ func TestGetMetadata(t *testing.T) {
 		config.Config{},
 		store,
 		nil, // controller not needed for metadata
+		nil, // scanCtx — defaults to context.Background()
+		nil, // scanWG — no in-flight tracking
 	)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/metadata", nil)
@@ -58,6 +63,8 @@ func TestAcceptScanRequest_Valid(t *testing.T) {
 		config.Config{},
 		store,
 		nil, // controller is nil; goroutine guards against nil
+		nil, // scanCtx
+		nil, // scanWG
 	)
 
 	scanReq := harbor.ScanRequest{
@@ -91,7 +98,7 @@ func TestAcceptScanRequest_Valid(t *testing.T) {
 
 func TestAcceptScanRequest_MissingFields(t *testing.T) {
 	store := memory.NewStore()
-	handler := NewAPIHandler(config.BuildInfo{}, config.Config{}, store, nil)
+	handler := NewAPIHandler(config.BuildInfo{}, config.Config{}, store, nil, nil, nil)
 
 	tests := []struct {
 		name    string
@@ -135,7 +142,7 @@ func TestAcceptScanRequest_MissingFields(t *testing.T) {
 
 func TestGetScanReport_NotFound(t *testing.T) {
 	store := memory.NewStore()
-	handler := NewAPIHandler(config.BuildInfo{}, config.Config{}, store, nil)
+	handler := NewAPIHandler(config.BuildInfo{}, config.Config{}, store, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/scan/nonexistent/report", nil)
 	w := httptest.NewRecorder()
@@ -154,7 +161,7 @@ func TestGetScanReport_Pending(t *testing.T) {
 		Status: persistence.Pending,
 	})
 
-	handler := NewAPIHandler(config.BuildInfo{}, config.Config{}, store, nil)
+	handler := NewAPIHandler(config.BuildInfo{}, config.Config{}, store, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/scan/test-job-1/report", nil)
 	w := httptest.NewRecorder()
@@ -176,7 +183,7 @@ func TestGetScanReport_Finished(t *testing.T) {
 		},
 	})
 
-	handler := NewAPIHandler(config.BuildInfo{}, config.Config{}, store, nil)
+	handler := NewAPIHandler(config.BuildInfo{}, config.Config{}, store, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/scan/test-job-2/report", nil)
 	w := httptest.NewRecorder()
@@ -205,7 +212,7 @@ func TestGetScanReport_Failed(t *testing.T) {
 		Error:  "image pull failed",
 	})
 
-	handler := NewAPIHandler(config.BuildInfo{}, config.Config{}, store, nil)
+	handler := NewAPIHandler(config.BuildInfo{}, config.Config{}, store, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/scan/test-job-3/report", nil)
 	w := httptest.NewRecorder()
@@ -218,7 +225,7 @@ func TestGetScanReport_Failed(t *testing.T) {
 }
 
 func TestHealthProbes(t *testing.T) {
-	handler := NewAPIHandler(config.BuildInfo{}, config.Config{}, memory.NewStore(), nil)
+	handler := NewAPIHandler(config.BuildInfo{}, config.Config{}, memory.NewStore(), nil, nil, nil)
 
 	tests := []struct {
 		path string
@@ -247,6 +254,7 @@ func TestHealthProbes(t *testing.T) {
 func TestReady_FailingCheck(t *testing.T) {
 	handler := NewAPIHandler(
 		config.BuildInfo{}, config.Config{}, memory.NewStore(), nil,
+		nil, nil, // scanCtx, scanWG
 		ReadinessCheck{
 			Name:  "kubernetes-client",
 			Check: func() error { return fmt.Errorf("k8s client unavailable") },
@@ -291,11 +299,113 @@ func TestReady_FailingCheck(t *testing.T) {
 	}
 }
 
+// blockingController captures the ctx it was called with and blocks on it
+// until cancellation. Used by the shutdown test to verify scan goroutines
+// inherit the process-lifetime context and exit cleanly when it cancels.
+type blockingController struct {
+	started   chan struct{} // closed once Scan is invoked
+	gotCtx    context.Context
+	gotCtxErr error
+	store     persistence.Store
+}
+
+func (b *blockingController) Scan(ctx context.Context, scanJobID string) error {
+	b.gotCtx = ctx
+	close(b.started)
+	<-ctx.Done()
+	b.gotCtxErr = ctx.Err()
+	if b.store != nil {
+		_ = b.store.UpdateStatus(context.Background(), scanJobID, persistence.Failed, "interrupted by pod shutdown")
+	}
+	return ctx.Err()
+}
+
+// TestAcceptScanRequest_GoroutineRespectsScanCtx pins issue #24: the async
+// scan goroutine launched from AcceptScanRequest must inherit the
+// process-lifetime scanCtx, NOT a detached context.Background(). When that
+// ctx is cancelled (on SIGTERM), the controller's blocking call returns
+// promptly and writes a terminal status to the store — instead of leaving
+// the job Pending until TTL expiry.
+func TestAcceptScanRequest_GoroutineRespectsScanCtx(t *testing.T) {
+	store := memory.NewStore()
+	scanCtx, cancelScans := context.WithCancel(context.Background())
+	defer cancelScans()
+	var scanWG sync.WaitGroup
+
+	bc := &blockingController{started: make(chan struct{}), store: store}
+
+	handler := NewAPIHandler(
+		config.BuildInfo{Version: "test"},
+		config.Config{},
+		store,
+		bc,
+		scanCtx,
+		&scanWG,
+	)
+
+	body, _ := json.Marshal(harbor.ScanRequest{
+		Registry: harbor.Registry{URL: "https://core.harbor.domain"},
+		Artifact: harbor.Artifact{Repository: "library/nginx", Digest: "sha256:abc"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/scan", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+	var scanResp harbor.ScanResponse
+	if err := json.NewDecoder(w.Body).Decode(&scanResp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// Wait for the goroutine to actually enter Scan(). If the handler
+	// detached the context, ctx.Done would never fire and the test would
+	// time out.
+	select {
+	case <-bc.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("controller.Scan was not invoked within 2s")
+	}
+
+	// Now simulate SIGTERM: cancel the parent. The goroutine should exit
+	// promptly and decrement scanWG.
+	cancelScans()
+
+	done := make(chan struct{})
+	go func() { scanWG.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scanWG did not drain within 2s; goroutine may be using a detached context")
+	}
+
+	if bc.gotCtxErr == nil {
+		t.Errorf("expected goroutine to observe ctx.Err on cancellation, got nil")
+	}
+
+	// Job should be Failed with the interruption message — not stuck Pending.
+	got, err := store.Get(context.Background(), scanResp.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("job missing from store")
+	}
+	if got.Status != persistence.Failed {
+		t.Errorf("expected status Failed, got %s", got.Status)
+	}
+	if got.Error == "" {
+		t.Errorf("expected job.Error to describe the interruption")
+	}
+}
+
 // TestReady_AllChecksPass confirms the all-pass path returns 200 and lists
 // each successful check by name.
 func TestReady_AllChecksPass(t *testing.T) {
 	handler := NewAPIHandler(
 		config.BuildInfo{}, config.Config{}, memory.NewStore(), nil,
+		nil, nil, // scanCtx, scanWG
 		ReadinessCheck{Name: "first", Check: func() error { return nil }},
 		ReadinessCheck{Name: "second", Check: func() error { return nil }},
 	)


### PR DESCRIPTION
## Summary

Fixes #24 — #15 made scan-job *records* durable via Redis, but scan execution was still a pod-local goroutine started with a detached \`context.Background()\`. On SIGTERM that goroutine vanished, leaving the job \`Pending\` in Redis until TTL expiry — and any other replica reading the same record kept returning 302 to Harbor for a scan that was no longer advancing.

This PR takes the **fail-fast** path the issue's acceptance criteria allow: graceful shutdown cancels in-flight scans and waits for them to record \`Failed("interrupted")\`.

## Approach

\`NewAPIHandler\` now takes a process-lifetime \`scanCtx context.Context\` and a \`*sync.WaitGroup\`. Both may be nil — handler falls back to \`context.Background()\` and skips wg tracking, so every existing test call site keeps working with two extra \`nil\` args.

\`AcceptScanRequest\`'s async goroutine inherits \`h.scanCtx\` (NOT \`context.Background()\` as before) and brackets its body with \`wg.Add(1)\` / \`defer wg.Done()\`.

\`main.go\` creates \`scanCtx, cancelScans := context.WithCancel(...)\` and a \`var scanWG sync.WaitGroup\`, threads them through. On SIGTERM the shutdown sequence is:

1. Stop accepting new HTTP requests and drain in-flight ones (10s budget).
2. \`cancelScans()\` — controller poll loops see \`<-ctx.Done()\`, return \`ctx.Err()\`, the wrapper \`Scan()\` writes \`Failed("interrupted by pod shutdown")\` to the store.
3. Wait up to 10s for \`scanWG\` to drain.
4. Exit.

## Limit (documented in README)

Ungraceful crashes (OOM, kernel kill) bypass step 3 so jobs they were running stay \`Pending\` until they expire via \`MEMORY_STORE_RETENTION\` or \`REDIS_JOB_TTL\`. Operators wanting faster orphan cleanup can lower the TTL.

## Tests

- **\`TestAcceptScanRequest_GoroutineRespectsScanCtx\`** — submits a scan against a \`blockingController\` that captures the ctx it received. Cancels the parent and asserts the goroutine wakes, \`scanWG\` drains, and the job is \`Failed\` in the store. **Would have failed under the previous code** (the goroutine used \`context.Background()\`).
- All existing handler tests pass with \`nil, nil\` injected for the new params; no behavior change.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` passes including the new test.
- [ ] End-to-end: kick off a scan with a slow kubevuln, send SIGTERM mid-scan, observe job becomes Failed within 10s instead of staying Pending until TTL.