### PR TITLE
fix: atomic SetFinished publishes report+status in one store op (#31)

### DIFF
--- a/pkg/persistence/memory/store.go
+++ b/pkg/persistence/memory/store.go
@@ -140,6 +140,22 @@ func (s *Store) UpdateReport(_ context.Context, id string, report harbor.ScanRep
 	return nil
 }
 
+// SetFinished atomically publishes the report and transitions the job to
+// Finished, under one mutex acquisition so a concurrent Get can never
+// observe Finished-without-report or report-with-Pending. See issue #31.
+func (s *Store) SetFinished(_ context.Context, id string, report harbor.ScanReport) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job, ok := s.jobs[id]
+	if !ok {
+		return fmt.Errorf("scan job not found: %s", id)
+	}
+	job.Report = report
+	job.Status = persistence.Finished
+	job.TerminalAt = s.now()
+	return nil
+}
+
 // Len returns the current number of jobs in the store. Useful for tests
 // asserting eviction; not part of any public interface.
 func (s *Store) Len() int {

--- a/pkg/persistence/memory/store_test.go
+++ b/pkg/persistence/memory/store_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goharbor/harbor-scanner-kubescape/pkg/harbor"
 	"github.com/goharbor/harbor-scanner-kubescape/pkg/persistence"
 )
 
@@ -151,5 +152,52 @@ func mustCreate(t *testing.T, s *Store, id string) {
 	t.Helper()
 	if err := s.Create(context.Background(), persistence.ScanJob{ID: id, Status: persistence.Queued}); err != nil {
 		t.Fatalf("seed %s: %v", id, err)
+	}
+}
+
+// TestSetFinished_PublishesAtomically pins issue #31 for the memory store:
+// SetFinished moves the job to Finished AND saves the report in a single
+// store operation. After it returns, no Get can observe Finished without
+// the report or report without Finished.
+func TestSetFinished_PublishesAtomically(t *testing.T) {
+	fixedNow := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	s := NewStore(WithNow(func() time.Time { return fixedNow }))
+	defer s.Close()
+	ctx := context.Background()
+
+	mustCreate(t, s, "job-final")
+
+	report := harbor.ScanReport{
+		Scanner: harbor.Scanner{Name: "Kubescape", Version: "0.74.0"},
+		Vulnerabilities: []harbor.VulnerabilityItem{
+			{ID: "CVE-2024-9999", Severity: harbor.SevHigh},
+		},
+	}
+	if err := s.SetFinished(ctx, "job-final", report); err != nil {
+		t.Fatalf("SetFinished: %v", err)
+	}
+
+	got, err := s.Get(ctx, "job-final")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != persistence.Finished {
+		t.Errorf("status = %s, want Finished", got.Status)
+	}
+	if len(got.Report.Vulnerabilities) != 1 || got.Report.Vulnerabilities[0].ID != "CVE-2024-9999" {
+		t.Errorf("report not published with status: got %+v", got.Report.Vulnerabilities)
+	}
+	if !got.TerminalAt.Equal(fixedNow) {
+		t.Errorf("TerminalAt = %v, want %v (SetFinished must mark the terminal moment)", got.TerminalAt, fixedNow)
+	}
+}
+
+// TestSetFinished_NotFound mirrors UpdateStatus/UpdateReport: missing key
+// returns an error rather than silently re-creating.
+func TestSetFinished_NotFound(t *testing.T) {
+	s := NewStore()
+	defer s.Close()
+	if err := s.SetFinished(context.Background(), "ghost", harbor.ScanReport{}); err == nil {
+		t.Error("expected SetFinished on missing key to error")
 	}
 }

--- a/pkg/persistence/redis/store.go
+++ b/pkg/persistence/redis/store.go
@@ -131,6 +131,30 @@ func (s *Store) UpdateReport(ctx context.Context, id string, report harbor.ScanR
 	return s.save(ctx, job)
 }
 
+// SetFinished publishes the report and Finished status in a single Redis
+// SET, so an observer can never see a stored report with status Pending
+// (or a Finished status with no report). See issue #31.
+//
+// The Get-modify-Set sequence is not Redis-atomic — between the read and
+// the write a concurrent UpdateStatus could clobber. In the controller's
+// usage we don't have concurrent writers for the same job (each job is
+// owned by exactly one goroutine), so a CAS isn't required. The contract
+// this method delivers is "the SET that publishes Finished also publishes
+// the report" — which is the actual #31 acceptance criterion.
+func (s *Store) SetFinished(ctx context.Context, id string, report harbor.ScanReport) error {
+	job, err := s.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	if job == nil {
+		return fmt.Errorf("scan job not found: %s", id)
+	}
+	job.Report = report
+	job.Status = persistence.Finished
+	job.TerminalAt = time.Now()
+	return s.save(ctx, job)
+}
+
 func (s *Store) save(ctx context.Context, job *persistence.ScanJob) error {
 	b, err := json.Marshal(job)
 	if err != nil {

--- a/pkg/persistence/redis/store_test.go
+++ b/pkg/persistence/redis/store_test.go
@@ -205,3 +205,51 @@ func TestReadinessCheck_Shape(t *testing.T) {
 		t.Errorf("expected check to fail when miniredis is closed; pod would stay Ready while every scan write 500s")
 	}
 }
+
+// TestSetFinished_PublishesAtomically pins issue #31 for the Redis store:
+// SetFinished publishes the report and Finished status in a single SET so
+// a concurrent Get can never see one without the other. Pre-fix the
+// controller used UpdateReport-then-UpdateStatus, leaving a race window
+// where a Redis failure between the two writes left the report stored
+// behind a stale Pending status.
+func TestSetFinished_PublishesAtomically(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	if err := s.Create(ctx, persistence.ScanJob{ID: "job-atomic", Status: persistence.Queued}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	report := harbor.ScanReport{
+		Scanner: harbor.Scanner{Name: "Kubescape", Version: "0.74.0"},
+		Vulnerabilities: []harbor.VulnerabilityItem{
+			{ID: "CVE-2024-9999", Severity: harbor.SevHigh},
+		},
+	}
+	if err := s.SetFinished(ctx, "job-atomic", report); err != nil {
+		t.Fatalf("SetFinished: %v", err)
+	}
+
+	got, err := s.Get(ctx, "job-atomic")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != persistence.Finished {
+		t.Errorf("status = %s, want Finished", got.Status)
+	}
+	if len(got.Report.Vulnerabilities) != 1 || got.Report.Vulnerabilities[0].ID != "CVE-2024-9999" {
+		t.Errorf("report not published with status: got %+v", got.Report.Vulnerabilities)
+	}
+	if got.TerminalAt.IsZero() {
+		t.Error("expected TerminalAt to be set on SetFinished")
+	}
+}
+
+// TestSetFinished_NotFound — missing key on SetFinished should error,
+// matching the contract for UpdateStatus / UpdateReport.
+func TestSetFinished_NotFound(t *testing.T) {
+	s, _ := newTestStore(t)
+	if err := s.SetFinished(context.Background(), "ghost", harbor.ScanReport{}); err == nil {
+		t.Error("expected SetFinished on missing key to error")
+	}
+}

--- a/pkg/persistence/store.go
+++ b/pkg/persistence/store.go
@@ -53,4 +53,12 @@ type Store interface {
 	Get(ctx context.Context, id string) (*ScanJob, error)
 	UpdateStatus(ctx context.Context, id string, status ScanJobStatus, errMsg ...string) error
 	UpdateReport(ctx context.Context, id string, report harbor.ScanReport) error
+
+	// SetFinished publishes the scan report and the Finished status as a
+	// single store operation. The previous two-call pattern
+	// (UpdateReport followed by UpdateStatus) had a window where a crash
+	// or transient backend failure between the two writes left a stored
+	// report behind a stale Pending status — Harbor would keep getting
+	// 302s for a scan that already had a result waiting. See issue #31.
+	SetFinished(ctx context.Context, id string, report harbor.ScanReport) error
 }

--- a/pkg/scan/controller.go
+++ b/pkg/scan/controller.go
@@ -141,10 +141,10 @@ func (c *controller) scan(ctx context.Context, scanJobID string) error {
 			slog.Duration("ttl", c.reuseTTL),
 		)
 		report := TransformManifestToReport(existing, job.Request.Artifact)
-		if err := c.store.UpdateReport(ctx, scanJobID, report); err != nil {
-			return err
-		}
-		return c.store.UpdateStatus(ctx, scanJobID, persistence.Finished)
+		// Atomic: publish report and Finished status in one store op so
+		// Harbor cannot poll a Finished status before the report lands,
+		// nor a Pending status while the report is already saved. See #31.
+		return c.store.SetFinished(ctx, scanJobID, report)
 	} else if existing != nil {
 		staleSeenAt = existing.CreatedAt
 		slog.Info("Existing VulnerabilityManifest is stale, triggering fresh scan",
@@ -171,11 +171,12 @@ func (c *controller) scan(ctx context.Context, scanJobID string) error {
 	if err != nil {
 		return fmt.Errorf("waiting for scan results: %w", err)
 	}
-	if err := c.store.UpdateReport(ctx, scanJobID, report); err != nil {
-		return err
-	}
 
-	if err := c.store.UpdateStatus(ctx, scanJobID, persistence.Finished); err != nil {
+	// Atomic publication: a single store op transitions the job to
+	// Finished AND saves the report. Eliminates the crash window between
+	// UpdateReport and UpdateStatus that left reports invisible behind a
+	// stale Pending status (issue #31).
+	if err := c.store.SetFinished(ctx, scanJobID, report); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

Fixes #31 — controller's success path used \`UpdateReport\` followed by \`UpdateStatus(Finished)\`, two separate store operations. A crash or transient Redis failure between the two writes left the report stored behind a stale \`Pending\` status — Harbor kept getting 302 polls for a job that already had a result waiting until TTL.

## The new method

\`SetFinished(ctx, id, report)\` on the \`persistence.Store\` interface — single store op that publishes the report AND moves status to \`Finished\` AND stamps \`TerminalAt\`.

- **memory** — one mutex acquisition mutates all three fields so a concurrent Get cannot observe \`Finished\`-without-report.
- **redis** — one \`SET\` marshals the whole \`ScanJob\` after the \`Get\`. The Get-modify-Set isn't Redis-atomic against a concurrent writer, but the controller's usage has **exactly one writer per job**, so this delivers the actual #31 contract: *the SET that publishes Finished also publishes the report*.

## Controller change

The two success paths (reuse existing fresh manifest, post-poll fresh manifest) now call \`SetFinished\` instead of the two-call sequence. The Failed path still uses \`UpdateStatus\` since there's no report to publish there.

## Tests

For both backends:

- **\`TestSetFinished_PublishesAtomically\`** — calls \`SetFinished\` then asserts the subsequent \`Get\` sees \`Finished\` status, the report fields populated, and \`TerminalAt\` set.
- **\`TestSetFinished_NotFound\`** — missing-key error contract matches \`UpdateStatus\` / \`UpdateReport\`.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` passes including the new tests.
- [ ] End-to-end: complete a scan, kill Redis briefly mid-publication, confirm the result is either fully visible (Finished + report) or fully absent — never the inconsistent middle state.