### PR TITLE
fix: re-read SA token + authenticated readiness check (#30)

### DIFF
--- a/cmd/scanner-kubescape/main.go
+++ b/cmd/scanner-kubescape/main.go
@@ -72,18 +72,23 @@ func run(ctx context.Context, cfg config.Config, buildInfo config.BuildInfo) err
 	// Initialize K8s client for VulnerabilityManifest CRD access.
 	// Uses in-cluster service account when running in Kubernetes.
 	// Falls back to no-K8s mode (direct kubevuln only) when not in cluster.
+	//
+	// The token is NOT read into memory once at startup — that pattern broke
+	// when kubelet rotated the projected token (#30). Instead the REST client
+	// reads it fresh from disk on every request via FileTokenSource.
+	const saTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 	var k8sClient k8s.Client
 	k8sAPIServer := os.Getenv("KUBERNETES_SERVICE_HOST")
-	k8sToken, _ := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
-	if k8sAPIServer != "" && len(k8sToken) > 0 {
+	if _, err := os.Stat(saTokenPath); err == nil && k8sAPIServer != "" {
 		k8sPort := os.Getenv("KUBERNETES_SERVICE_PORT")
 		if k8sPort == "" {
 			k8sPort = "443"
 		}
 		baseURL := "https://" + k8sAPIServer + ":" + k8sPort
-		k8sClient = k8s.NewRESTClient(baseURL, string(k8sToken))
+		k8sClient = k8s.NewRESTClient(baseURL, k8s.FileTokenSource(saTokenPath))
 		slog.Info("K8s client initialized for VulnerabilityManifest CRD access",
 			slog.String("api_server", baseURL),
+			slog.String("token_path", saTokenPath),
 		)
 	} else {
 		slog.Warn("Not running in Kubernetes cluster — VulnerabilityManifest CRD lookup disabled. " +
@@ -105,12 +110,20 @@ func run(ctx context.Context, cfg config.Config, buildInfo config.BuildInfo) err
 	//     runtime takes the pod out of rotation. See issue #25.
 	readiness := []v1.ReadinessCheck{
 		{
+			// Authenticated kubernetes-client check (issue #30).
+			// Pre-#30 this was a nil check, which silently stayed green
+			// after a token rotation 401 — the pod looked Ready while
+			// every scan returned 500. Now we hit /version on each probe
+			// with the freshest token, so 401/403/network errors take
+			// the pod NotReady.
 			Name: "kubernetes-client",
 			Check: func() error {
 				if k8sClient == nil {
 					return fmt.Errorf("kubernetes client unavailable; pod cannot read VulnerabilityManifest CRDs")
 				}
-				return nil
+				ctx, cancel := context.WithTimeout(context.Background(), readinessCheckTimeout)
+				defer cancel()
+				return k8sClient.Ping(ctx)
 			},
 		},
 	}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -59,6 +59,12 @@ type Client interface {
 	// ListVulnerabilityManifests lists VulnerabilityManifests in a namespace,
 	// optionally filtered by label selector.
 	ListVulnerabilityManifests(ctx context.Context, namespace, labelSelector string) ([]VulnerabilityManifest, error)
+
+	// Ping verifies connectivity to the Kubernetes API and that the
+	// current bearer token is still valid. Used by the readiness probe so
+	// post-rotation auth failures take the pod out of rotation instead of
+	// only surfacing at scan time. See issue #30.
+	Ping(ctx context.Context) error
 }
 
 const (

--- a/pkg/k8s/rest_client.go
+++ b/pkg/k8s/rest_client.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	neturl "net/url"
 	"os"
+	"strings"
 	"time"
 
 	v1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
@@ -30,17 +31,47 @@ import (
 // schema in kubescape/storage, but kubevuln/Grype payloads do carry them.
 // We parse them out via a tiny overlay decode against the raw response
 // body. See issue #5.
+// TokenSource returns the current bearer token to use for the next API
+// request. RESTClient calls it on every request so that kubelet's
+// projected-token rotation is picked up without restart. See issue #30.
+type TokenSource func() (string, error)
+
+// FileTokenSource reads a bearer token from disk on every call. Production
+// uses this with /var/run/secrets/kubernetes.io/serviceaccount/token, which
+// kubelet rewrites periodically.
+func FileTokenSource(path string) TokenSource {
+	return func() (string, error) {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("reading service account token from %s: %w", path, err)
+		}
+		return strings.TrimSpace(string(b)), nil
+	}
+}
+
+// StaticTokenSource returns the same token forever. Useful for tests that
+// don't need to exercise rotation.
+func StaticTokenSource(token string) TokenSource {
+	return func() (string, error) { return token, nil }
+}
+
 type RESTClient struct {
 	baseURL    string
 	httpClient *http.Client
-	token      string
+	tokenSrc   TokenSource
 }
 
 // NewRESTClient creates a Client that reads VulnerabilityManifest CRDs via the K8s API.
+//
 // baseURL is the Kubernetes API server URL (e.g., https://kubernetes.default.svc).
-// token is a ServiceAccount bearer token.
-// It automatically loads the in-cluster CA certificate for TLS verification.
-func NewRESTClient(baseURL, token string) *RESTClient {
+// tokenSrc supplies a fresh bearer token on every request. In production, use
+// FileTokenSource("/var/run/secrets/kubernetes.io/serviceaccount/token") so
+// kubelet's projected-token rotation is honored automatically (issue #30);
+// pre-#30 we cached the token at startup and silently 401'd after rotation.
+//
+// The constructor automatically loads the in-cluster CA certificate for TLS
+// verification.
+func NewRESTClient(baseURL string, tokenSrc TokenSource) *RESTClient {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 
 	// Load in-cluster CA cert for TLS verification against the K8s API server.
@@ -65,8 +96,20 @@ func NewRESTClient(baseURL, token string) *RESTClient {
 			Timeout:   30 * time.Second,
 			Transport: transport,
 		},
-		token: token,
+		tokenSrc: tokenSrc,
 	}
+}
+
+// authorize attaches the freshest bearer token to the request. Callers in
+// this package must use this instead of setting Authorization directly so
+// rotation (issue #30) takes effect.
+func (c *RESTClient) authorize(req *http.Request) error {
+	token, err := c.tokenSrc()
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	return nil
 }
 
 const (
@@ -105,7 +148,9 @@ func (c *RESTClient) GetVulnerabilityManifest(ctx context.Context, namespace, na
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
+	if err := c.authorize(req); err != nil {
+		return nil, err
+	}
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := c.httpClient.Do(req)
@@ -148,7 +193,9 @@ func (c *RESTClient) ListVulnerabilityManifests(ctx context.Context, namespace, 
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
+	if err := c.authorize(req); err != nil {
+		return nil, err
+	}
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := c.httpClient.Do(req)
@@ -172,6 +219,39 @@ func (c *RESTClient) ListVulnerabilityManifests(ctx context.Context, namespace, 
 		result = append(result, *canonicalToManifest(&list.Items[i]))
 	}
 	return result, nil
+}
+
+// Ping verifies that the Kubernetes API is reachable AND the current bearer
+// token is accepted. Hits /version (a small cheap endpoint that requires
+// auth on most clusters; an authenticated 200 is the strongest signal we
+// can get without actually scanning a CRD). Used by /probe/ready so that
+// post-rotation auth failures move the pod out of rotation. See issue #30.
+func (c *RESTClient) Ping(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/version", nil)
+	if err != nil {
+		return fmt.Errorf("creating ping request: %w", err)
+	}
+	if err := c.authorize(req); err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("k8s ping: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("k8s API rejected token (HTTP %d) — likely token rotation not picked up", resp.StatusCode)
+	}
+	if resp.StatusCode >= 500 {
+		return fmt.Errorf("k8s API ping returned %d", resp.StatusCode)
+	}
+	// 200 ideal; some restricted clusters return 403 for /version. Treat
+	// any 2xx/4xx-other-than-401/403 as healthy: we proved we can reach
+	// the API and authentication didn't bounce us.
+	return nil
 }
 
 // canonicalToManifest converts the kubescape/storage v1beta1 type into the

--- a/pkg/k8s/rest_client_test.go
+++ b/pkg/k8s/rest_client_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -68,7 +71,7 @@ func TestGetVulnerabilityManifest_CanonicalUnmarshal(t *testing.T) {
 	srv := newCRDServer(crdJSON)
 	defer srv.Close()
 
-	c := NewRESTClient(srv.URL, "test-token")
+	c := NewRESTClient(srv.URL, StaticTokenSource("test-token"))
 
 	vm, err := c.GetVulnerabilityManifest(context.Background(), "kubescape", "core.harbor.domain-library-nginx-abc123")
 	if err != nil {
@@ -194,7 +197,7 @@ func TestGetVulnerabilityManifest_CweExtraction(t *testing.T) {
 	srv := newCRDServer(crdJSON)
 	defer srv.Close()
 
-	c := NewRESTClient(srv.URL, "test-token")
+	c := NewRESTClient(srv.URL, StaticTokenSource("test-token"))
 
 	vm, err := c.GetVulnerabilityManifest(context.Background(), "kubescape", "core.harbor.domain-library-nginx-abc123")
 	if err != nil {
@@ -227,7 +230,7 @@ func TestGetVulnerabilityManifest_NotFound(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewRESTClient(srv.URL, "test-token")
+	c := NewRESTClient(srv.URL, StaticTokenSource("test-token"))
 
 	vm, err := c.GetVulnerabilityManifest(context.Background(), "kubescape", "missing")
 	if err != nil {
@@ -259,4 +262,91 @@ func equalStrings(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// TestFileTokenSource_RereadsOnEveryCall pins issue #30: the REST client
+// must pick up service-account token rotation. We point FileTokenSource at
+// a temp file, observe the bearer token sent to a httptest server, then
+// rewrite the file and observe the new token on the next request — without
+// reconstructing the client.
+func TestFileTokenSource_RereadsOnEveryCall(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenPath, []byte("token-v1"), 0600); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+
+	var seenAuth atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"major":"1","minor":"29"}`))
+	}))
+	defer srv.Close()
+
+	c := NewRESTClient(srv.URL, FileTokenSource(tokenPath))
+
+	if err := c.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping #1: %v", err)
+	}
+	if got := seenAuth.Load().(string); got != "Bearer token-v1" {
+		t.Errorf("first Ping Authorization = %q, want Bearer token-v1", got)
+	}
+
+	// Simulate kubelet rotating the token file underneath us.
+	if err := os.WriteFile(tokenPath, []byte("token-v2"), 0600); err != nil {
+		t.Fatalf("rotate token: %v", err)
+	}
+
+	if err := c.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping #2: %v", err)
+	}
+	if got := seenAuth.Load().(string); got != "Bearer token-v2" {
+		t.Errorf("post-rotation Authorization = %q, want Bearer token-v2 — token was cached at startup, regression on issue #30", got)
+	}
+}
+
+// TestPing_SurfacesAuthFailure confirms that a 401 from the K8s API turns
+// into a Ping error, which is what the readiness check uses to flip the
+// pod to NotReady.
+func TestPing_SurfacesAuthFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewRESTClient(srv.URL, StaticTokenSource("expired"))
+
+	err := c.Ping(context.Background())
+	if err == nil {
+		t.Fatal("expected Ping to fail when API returns 401")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected error to mention 401, got %v", err)
+	}
+}
+
+// TestPing_OK covers the happy path so a regression that ALWAYS errors
+// would be caught.
+func TestPing_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"major":"1","minor":"29"}`))
+	}))
+	defer srv.Close()
+
+	c := NewRESTClient(srv.URL, StaticTokenSource("test-token"))
+	if err := c.Ping(context.Background()); err != nil {
+		t.Errorf("Ping should succeed, got %v", err)
+	}
+}
+
+// TestFileTokenSource_MissingFile surfaces a helpful error when the SA
+// token path is wrong. main.go gates on os.Stat at startup so this won't
+// happen in production, but the failure mode should still be informative.
+func TestFileTokenSource_MissingFile(t *testing.T) {
+	src := FileTokenSource("/nonexistent/no/such/path")
+	if _, err := src(); err == nil {
+		t.Error("expected error reading missing token file")
+	}
 }

--- a/pkg/scan/controller_test.go
+++ b/pkg/scan/controller_test.go
@@ -35,6 +35,8 @@ func (f *fakeK8sClient) ListVulnerabilityManifests(_ context.Context, _, _ strin
 	return nil, nil
 }
 
+func (f *fakeK8sClient) Ping(_ context.Context) error { return nil }
+
 // fakeScanner increments triggers on every call.
 type fakeScanner struct {
 	triggers int


### PR DESCRIPTION
## Summary

Fixes #30 — \`RESTClient\` cached the service-account token on the struct at construction time. Kubelet rotates projected tokens periodically; long-lived pods would 401 silently after rotation. Worse, \`/probe/ready\` only checked \`k8sClient != nil\`, so a token-rotated pod stayed Ready while every scan returned 500.

## Approach

**1. \`TokenSource func() (string, error)\` called on every request.**

\`FileTokenSource(path)\` reads from disk on each call — kubelet's in-place rewrite is picked up automatically, no client reconstruction. \`StaticTokenSource(s)\` is provided for tests that don't exercise rotation.

The token isn't held on \`RESTClient\` anywhere — just sourced per request via the new \`authorize(req)\` helper.

**2. \`Ping(ctx)\` on \`k8s.Client\`.**

\`RESTClient\` implements it as a small authenticated \`GET /version\` (cheap, hits the api-aggregator path that requires auth). The \`kubernetes-client\` readiness check in \`main.go\` now calls \`Ping\` with a 2s timeout. 401 / 403 / network errors take the pod NotReady — instead of staying green and 500-ing every scan.

## Tests

- **\`TestFileTokenSource_RereadsOnEveryCall\`** — pin for the rotation behavior. Points \`FileTokenSource\` at a temp file, observes the Bearer header sent to a httptest server, rewrites the file mid-test, asserts the second request uses the new token. **Would fail under the old code** (cached at startup).
- **\`TestPing_SurfacesAuthFailure\`** — server returns 401, \`Ping\` must error so the readiness check trips.
- **\`TestPing_OK\`** — happy path, would catch a regression that always errors.
- **\`TestFileTokenSource_MissingFile\`** — informative error on a bad path.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` passes including the new tests.
- [ ] End-to-end: deploy with \`automountServiceAccountToken: true\`, simulate rotation by \`kubectl exec\` overwriting the token file with garbage, observe pod become NotReady within ~10s.

## Interaction with #29 / #31

Independent of those PRs — different files. Will rebase if conflicts emerge after merging the others first.