### PR TITLE
fix: probe VulnerabilityManifest read in /probe/ready, not /version (#35)

### DIFF
--- a/cmd/scanner-kubescape/main.go
+++ b/cmd/scanner-kubescape/main.go
@@ -110,12 +110,11 @@ func run(ctx context.Context, cfg config.Config, buildInfo config.BuildInfo) err
 	//     runtime takes the pod out of rotation. See issue #25.
 	readiness := []v1.ReadinessCheck{
 		{
-			// Authenticated kubernetes-client check (issue #30).
-			// Pre-#30 this was a nil check, which silently stayed green
-			// after a token rotation 401 — the pod looked Ready while
-			// every scan returned 500. Now we hit /version on each probe
-			// with the freshest token, so 401/403/network errors take
-			// the pod NotReady.
+			// Authenticated VulnerabilityManifest-access check (issues
+			// #16, #30, #35). Hits the same resource type and namespace
+			// the scan path uses, so probe success is direct evidence
+			// the adapter can actually serve. 401/403/network errors
+			// take the pod NotReady; 200/404 keep it Ready.
 			Name: "kubernetes-client",
 			Check: func() error {
 				if k8sClient == nil {
@@ -123,7 +122,7 @@ func run(ctx context.Context, cfg config.Config, buildInfo config.BuildInfo) err
 				}
 				ctx, cancel := context.WithTimeout(context.Background(), readinessCheckTimeout)
 				defer cancel()
-				return k8sClient.Ping(ctx)
+				return k8sClient.Ping(ctx, cfg.Kubevuln.Namespace)
 			},
 		},
 	}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -60,11 +60,21 @@ type Client interface {
 	// optionally filtered by label selector.
 	ListVulnerabilityManifests(ctx context.Context, namespace, labelSelector string) ([]VulnerabilityManifest, error)
 
-	// Ping verifies connectivity to the Kubernetes API and that the
-	// current bearer token is still valid. Used by the readiness probe so
-	// post-rotation auth failures take the pod out of rotation instead of
-	// only surfacing at scan time. See issue #30.
-	Ping(ctx context.Context) error
+	// Ping verifies that the adapter can actually read VulnerabilityManifest
+	// CRDs in the given namespace. Used by the readiness probe.
+	//
+	// The probe path matches the capability the adapter actually depends on
+	// for scan lookup — it issues GET on a guaranteed-missing
+	// VulnerabilityManifest, so a successful 404 is the strongest "yes I
+	// have access to this resource type" signal. /version (the previous
+	// probe path, #30) doesn't prove that: stricter clusters can 403 it
+	// even with valid CRD RBAC, while permissive clusters can 200 it
+	// without proving anything about the resource type the chart's RBAC
+	// only covers `vulnerabilitymanifests`. See issue #35.
+	//
+	// Implementations should treat 200 and 404 as healthy and 401/403 as
+	// unhealthy.
+	Ping(ctx context.Context, namespace string) error
 }
 
 const (

--- a/pkg/k8s/rest_client.go
+++ b/pkg/k8s/rest_client.go
@@ -221,13 +221,27 @@ func (c *RESTClient) ListVulnerabilityManifests(ctx context.Context, namespace, 
 	return result, nil
 }
 
-// Ping verifies that the Kubernetes API is reachable AND the current bearer
-// token is accepted. Hits /version (a small cheap endpoint that requires
-// auth on most clusters; an authenticated 200 is the strongest signal we
-// can get without actually scanning a CRD). Used by /probe/ready so that
-// post-rotation auth failures move the pod out of rotation. See issue #30.
-func (c *RESTClient) Ping(ctx context.Context) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/version", nil)
+// readinessProbeName is GET-d by Ping on the configured namespace. The
+// name is intentionally weird so it doesn't collide with a real CRD that
+// kubevuln might write.
+const readinessProbeName = "harbor-scanner-readiness-probe-does-not-exist"
+
+// Ping verifies that the adapter can actually issue authenticated reads
+// against the VulnerabilityManifest resource type — the same capability
+// the scan path depends on. Issues GET on a guaranteed-missing CRD in
+// `namespace` and treats 200 or 404 as healthy: both prove we reached
+// the API server, the token was accepted, and we have read access on
+// vulnerabilitymanifests. 401/403 surface as errors so /probe/ready
+// flips the pod NotReady; other failures (5xx, network) likewise.
+//
+// See issue #35 — the previous /version-based probe was misaligned with
+// the chart's RBAC and could be both falsely-NotReady on stricter clusters
+// and falsely-Ready on permissive ones.
+func (c *RESTClient) Ping(ctx context.Context, namespace string) error {
+	url := fmt.Sprintf("%s/apis/%s/%s/namespaces/%s/%s/%s",
+		c.baseURL, apiGroup, apiVersion, namespace, resource, readinessProbeName)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("creating ping request: %w", err)
 	}
@@ -242,16 +256,17 @@ func (c *RESTClient) Ping(ctx context.Context) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return fmt.Errorf("k8s API rejected token (HTTP %d) — likely token rotation not picked up", resp.StatusCode)
-	}
-	if resp.StatusCode >= 500 {
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusNotFound:
+		// 200: probe CRD exists by that name (extremely unlikely)
+		// 404: doesn't exist; we still proved read access on the type
+		// Both signal the adapter can perform real scan lookups.
+		return nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("k8s API rejected VulnerabilityManifest GET (HTTP %d) — likely token rotation not picked up or RBAC missing", resp.StatusCode)
+	default:
 		return fmt.Errorf("k8s API ping returned %d", resp.StatusCode)
 	}
-	// 200 ideal; some restricted clusters return 403 for /version. Treat
-	// any 2xx/4xx-other-than-401/403 as healthy: we proved we can reach
-	// the API and authentication didn't bounce us.
-	return nil
 }
 
 // canonicalToManifest converts the kubescape/storage v1beta1 type into the

--- a/pkg/k8s/rest_client_test.go
+++ b/pkg/k8s/rest_client_test.go
@@ -286,7 +286,7 @@ func TestFileTokenSource_RereadsOnEveryCall(t *testing.T) {
 
 	c := NewRESTClient(srv.URL, FileTokenSource(tokenPath))
 
-	if err := c.Ping(context.Background()); err != nil {
+	if err := c.Ping(context.Background(), "kubescape"); err != nil {
 		t.Fatalf("Ping #1: %v", err)
 	}
 	if got := seenAuth.Load().(string); got != "Bearer token-v1" {
@@ -298,7 +298,7 @@ func TestFileTokenSource_RereadsOnEveryCall(t *testing.T) {
 		t.Fatalf("rotate token: %v", err)
 	}
 
-	if err := c.Ping(context.Background()); err != nil {
+	if err := c.Ping(context.Background(), "kubescape"); err != nil {
 		t.Fatalf("Ping #2: %v", err)
 	}
 	if got := seenAuth.Load().(string); got != "Bearer token-v2" {
@@ -317,7 +317,7 @@ func TestPing_SurfacesAuthFailure(t *testing.T) {
 
 	c := NewRESTClient(srv.URL, StaticTokenSource("expired"))
 
-	err := c.Ping(context.Background())
+	err := c.Ping(context.Background(), "kubescape")
 	if err == nil {
 		t.Fatal("expected Ping to fail when API returns 401")
 	}
@@ -336,7 +336,7 @@ func TestPing_OK(t *testing.T) {
 	defer srv.Close()
 
 	c := NewRESTClient(srv.URL, StaticTokenSource("test-token"))
-	if err := c.Ping(context.Background()); err != nil {
+	if err := c.Ping(context.Background(), "kubescape"); err != nil {
 		t.Errorf("Ping should succeed, got %v", err)
 	}
 }
@@ -348,5 +348,81 @@ func TestFileTokenSource_MissingFile(t *testing.T) {
 	src := FileTokenSource("/nonexistent/no/such/path")
 	if _, err := src(); err == nil {
 		t.Error("expected error reading missing token file")
+	}
+}
+
+// TestPing_NotFoundIsHealthy pins the headline behavior of issue #35: a
+// 404 on the probe CRD must be treated as healthy. That's the *expected*
+// response — the probe name is intentionally invented, so 404 is exactly
+// what proves we have read access on the resource type. Pre-#35 the probe
+// was /version and a 404 there would not have happened; under the new
+// CRD probe, anything but 200/404 must mean trouble.
+func TestPing_NotFoundIsHealthy(t *testing.T) {
+	var seenPath atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath.Store(r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewRESTClient(srv.URL, StaticTokenSource("test-token"))
+	if err := c.Ping(context.Background(), "kubescape"); err != nil {
+		t.Errorf("Ping should treat 404 on the probe CRD as healthy, got %v", err)
+	}
+
+	// Verify the probe actually hits the VulnerabilityManifest path so a
+	// regression to /version (or anything else) surfaces here.
+	path, _ := seenPath.Load().(string)
+	if !strings.Contains(path, "/vulnerabilitymanifests/") {
+		t.Errorf("Ping URL = %q, want a path under /vulnerabilitymanifests/ — readiness must exercise the same RBAC the chart grants (issue #35)", path)
+	}
+	if !strings.Contains(path, "/namespaces/kubescape/") {
+		t.Errorf("Ping URL = %q, want the configured namespace `kubescape` to be in the path", path)
+	}
+	if strings.Contains(path, "/version") {
+		t.Errorf("Ping URL = %q, regressed to /version probe (issue #35)", path)
+	}
+}
+
+// TestPing_ForbiddenIsUnhealthy pins the other half of #35: 403 must trip
+// readiness even though /version on permissive clusters might have
+// returned 200 for an otherwise-broken pod.
+func TestPing_ForbiddenIsUnhealthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := NewRESTClient(srv.URL, StaticTokenSource("limited"))
+
+	err := c.Ping(context.Background(), "kubescape")
+	if err == nil {
+		t.Fatal("expected Ping to fail when probe CRD GET returns 403")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("expected error to mention 403, got %v", err)
+	}
+}
+
+// TestPing_ProbesVulnerabilityManifestPath confirms the probe URL shape on
+// the happy path too, so a regression that 200's any path won't slip past
+// review unnoticed.
+func TestPing_ProbesVulnerabilityManifestPath(t *testing.T) {
+	var seenPath atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath.Store(r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewRESTClient(srv.URL, StaticTokenSource("test-token"))
+	if err := c.Ping(context.Background(), "myns"); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+
+	path, _ := seenPath.Load().(string)
+	wantPrefix := "/apis/spdx.softwarecomposition.kubescape.io/v1beta1/namespaces/myns/vulnerabilitymanifests/"
+	if !strings.HasPrefix(path, wantPrefix) {
+		t.Errorf("Ping URL = %q, want prefix %q", path, wantPrefix)
 	}
 }

--- a/pkg/scan/controller_test.go
+++ b/pkg/scan/controller_test.go
@@ -38,7 +38,7 @@ func (f *fakeK8sClient) ListVulnerabilityManifests(_ context.Context, _, _ strin
 	return nil, nil
 }
 
-func (f *fakeK8sClient) Ping(_ context.Context) error { return nil }
+func (f *fakeK8sClient) Ping(_ context.Context, _ string) error { return nil }
 
 // fakeScanner increments triggers on every call.
 type fakeScanner struct {


### PR DESCRIPTION
## Summary

Fixes #35 — the \`/version\` probe introduced in #30 isn't aligned with the chart's actual RBAC. The ServiceAccount only gets \`get/list\` on \`vulnerabilitymanifests\`, so:

- **Stricter clusters** can 403 \`/version\` even with valid CRD access → pod stays NotReady incorrectly.
- **Permissive clusters** can 200 \`/version\` without proving anything about the CRD type → pod stays Ready while real scan lookups fail later.

## Approach

Rewrite \`Ping\` to GET a guaranteed-missing \`VulnerabilityManifest\` in the configured namespace. The URL shape matches what the scan path uses, so a successful probe = direct evidence the adapter can serve.

Status mapping:

| Code | Verdict | Why |
|---|---|---|
| 200 | healthy | the absurdly-named probe CRD somehow exists |
| 404 | healthy | we have read access on the resource type but not that name — exactly the expected response |
| 401, 403 | unhealthy | token rotation not picked up, or RBAC missing/revoked |
| other 5xx, network | unhealthy | API not reachable |

\`Ping\`'s signature changes from \`Ping(ctx)\` to \`Ping(ctx, namespace)\` since the probe needs to know which namespace to hit. \`main.go\`'s readiness check passes \`cfg.Kubevuln.Namespace\`; the test fake is updated to match.

## Tests

- **\`TestPing_NotFoundIsHealthy\`** — pin for the headline behavior: 404 returns nil. Also verifies the request URL hits \`/vulnerabilitymanifests/\` (not \`/version\`) and contains the configured namespace, so a regression to the old probe path surfaces here.
- **\`TestPing_ForbiddenIsUnhealthy\`** — 403 must trip readiness even though pre-#35 \`/version\` on permissive clusters might have stayed green.
- **\`TestPing_ProbesVulnerabilityManifestPath\`** — pins the full URL prefix so a regression that 200s any path won't slip past review.
- All existing tests continue to pass.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` passes including the four new cases.
- [ ] End-to-end: deploy on a cluster that 403s \`/version\` to non-cluster-admins (stricter cluster) but grants \`get/list\` on \`vulnerabilitymanifests\` per the chart RBAC, observe pod becomes Ready (would be NotReady under the old probe). Then revoke the RBAC and observe NotReady.