### PR TITLE
fix: narrow 404 handling to specific named-object-missing case (#37)

### DIFF
--- a/pkg/k8s/rest_client.go
+++ b/pkg/k8s/rest_client.go
@@ -159,17 +159,25 @@ func (c *RESTClient) GetVulnerabilityManifest(ctx context.Context, namespace, na
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, nil
-	}
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("K8s API returned %d: %s", resp.StatusCode, string(body))
-	}
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading VulnerabilityManifest: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		// Narrow 404 handling: only the specific "named object missing"
+		// case is benign. A 404 for a missing namespace, an unserved
+		// resource path, or a broken aggregator must surface as an error
+		// — otherwise GetVulnerabilityManifest silently returns "no scan
+		// result yet" and the controller polls until timeout instead of
+		// failing fast. See issue #37.
+		if isNamedObjectNotFound(body, resource, name) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("K8s API 404 not for the requested object (likely missing namespace, unserved resource type, or broken path): %s", string(body))
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("K8s API returned %d: %s", resp.StatusCode, string(body))
 	}
 
 	var crd v1beta1.VulnerabilityManifest
@@ -256,17 +264,62 @@ func (c *RESTClient) Ping(ctx context.Context, namespace string) error {
 	}
 	defer resp.Body.Close()
 
+	body, _ := io.ReadAll(resp.Body)
+
 	switch resp.StatusCode {
-	case http.StatusOK, http.StatusNotFound:
-		// 200: probe CRD exists by that name (extremely unlikely)
-		// 404: doesn't exist; we still proved read access on the type
-		// Both signal the adapter can perform real scan lookups.
+	case http.StatusOK:
+		// Probe CRD exists by that name (extremely unlikely with our
+		// chosen name, but means we have read access — healthy).
 		return nil
+	case http.StatusNotFound:
+		// Healthy ONLY when the 404 is the specific "probe object not
+		// found" Status. A 404 for a missing namespace or an unserved
+		// resource type would falsely keep readiness green even though
+		// real scan lookups can't work. See issue #37.
+		if isNamedObjectNotFound(body, resource, readinessProbeName) {
+			return nil
+		}
+		return fmt.Errorf("k8s API 404 not for the probe object (likely missing namespace, unserved resource type, or broken path): %s", string(body))
 	case http.StatusUnauthorized, http.StatusForbidden:
 		return fmt.Errorf("k8s API rejected VulnerabilityManifest GET (HTTP %d) — likely token rotation not picked up or RBAC missing", resp.StatusCode)
 	default:
-		return fmt.Errorf("k8s API ping returned %d", resp.StatusCode)
+		return fmt.Errorf("k8s API ping returned %d: %s", resp.StatusCode, string(body))
 	}
+}
+
+// isNamedObjectNotFound reports whether the body of a 404 response from
+// the K8s API is the specific "named object does not exist" Status — as
+// opposed to a path-level 404 (missing namespace, unserved resource type,
+// broken aggregator). The named-object case is benign for both the scan
+// path and the readiness probe; the others are configuration errors that
+// should surface to the caller. See issue #37.
+//
+// We require all four signals: a Status object body, reason=NotFound,
+// details.kind matches the requested resource (so a missing-namespace
+// 404 — whose details.kind would be "namespaces" — is rejected), and
+// details.name matches the requested object name.
+func isNamedObjectNotFound(body []byte, expectedResource, expectedName string) bool {
+	var st struct {
+		Kind    string `json:"kind"`
+		Reason  string `json:"reason"`
+		Details struct {
+			Name string `json:"name"`
+			Kind string `json:"kind"`
+		} `json:"details"`
+	}
+	if err := json.Unmarshal(body, &st); err != nil {
+		return false
+	}
+	if st.Kind != "Status" || st.Reason != "NotFound" {
+		return false
+	}
+	if st.Details.Kind != expectedResource {
+		return false
+	}
+	if st.Details.Name != expectedName {
+		return false
+	}
+	return true
 }
 
 // canonicalToManifest converts the kubescape/storage v1beta1 type into the

--- a/pkg/k8s/rest_client_test.go
+++ b/pkg/k8s/rest_client_test.go
@@ -2,6 +2,8 @@ package k8s
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -224,9 +226,41 @@ func TestGetVulnerabilityManifest_CweExtraction(t *testing.T) {
 	}
 }
 
-func TestGetVulnerabilityManifest_NotFound(t *testing.T) {
+// notFoundStatusJSON builds a Kubernetes Status object body for a 404
+// "named object missing" response — the only 404 shape we treat as
+// benign (issue #37). Used by tests that want to simulate the K8s API
+// server's own NotFound payload. We marshal a real struct so the JSON
+// quoting is correct (a previous attempt that string-formatted via %q
+// produced invalid JSON).
+func notFoundStatusJSON(resourceKind, name string) string {
+	body := map[string]any{
+		"kind":       "Status",
+		"apiVersion": "v1",
+		"status":     "Failure",
+		"reason":     "NotFound",
+		"message":    fmt.Sprintf("%s %q not found", resourceKind, name),
+		"details": map[string]any{
+			"name": name,
+			"kind": resourceKind,
+		},
+		"code": 404,
+	}
+	b, err := json.Marshal(body)
+	if err != nil {
+		panic(err) // unreachable for the values we feed
+	}
+	return string(b)
+}
+
+// TestGetVulnerabilityManifest_NamedObjectNotFoundIsBenign covers the
+// "no scan result yet" path: when the K8s API returns a Status body for
+// the specific requested CRD name, the controller treats it as a normal
+// miss and keeps polling. See issue #37.
+func TestGetVulnerabilityManifest_NamedObjectNotFoundIsBenign(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		http.NotFound(w, &http.Request{})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(notFoundStatusJSON("vulnerabilitymanifests", "missing")))
 	}))
 	defer srv.Close()
 
@@ -234,10 +268,79 @@ func TestGetVulnerabilityManifest_NotFound(t *testing.T) {
 
 	vm, err := c.GetVulnerabilityManifest(context.Background(), "kubescape", "missing")
 	if err != nil {
-		t.Fatalf("expected nil error on 404, got %v", err)
+		t.Fatalf("expected nil error on benign object-missing 404, got %v", err)
 	}
 	if vm != nil {
-		t.Errorf("expected nil manifest on 404, got %+v", vm)
+		t.Errorf("expected nil manifest on benign 404, got %+v", vm)
+	}
+}
+
+// TestGetVulnerabilityManifest_BareNotFoundIsError pins the headline of
+// issue #37: a 404 with no Kubernetes Status body (e.g. when the apiserver
+// has no route for the resource at all, or an aggregator is missing) must
+// surface as an error so the controller fails fast instead of polling
+// until timeout for a scan it can never observe.
+func TestGetVulnerabilityManifest_BareNotFoundIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.NotFound(w, &http.Request{}) // text/plain "404 page not found"
+	}))
+	defer srv.Close()
+
+	c := NewRESTClient(srv.URL, StaticTokenSource("test-token"))
+
+	vm, err := c.GetVulnerabilityManifest(context.Background(), "kubescape", "missing")
+	if err == nil {
+		t.Fatalf("expected error for bare 404 (broken path / unserved resource), got nil with vm=%+v", vm)
+	}
+	if vm != nil {
+		t.Errorf("expected nil manifest on error path, got %+v", vm)
+	}
+}
+
+// TestGetVulnerabilityManifest_NamespaceNotFoundIsError covers the
+// missing-namespace case from #37. K8s returns a Status whose
+// details.kind is "namespaces", not "vulnerabilitymanifests". We must
+// reject it so a misconfigured KUBEVULN_NAMESPACE doesn't masquerade as
+// a normal "no scan yet" response.
+func TestGetVulnerabilityManifest_NamespaceNotFoundIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(notFoundStatusJSON("namespaces", "kubescape")))
+	}))
+	defer srv.Close()
+
+	c := NewRESTClient(srv.URL, StaticTokenSource("test-token"))
+
+	vm, err := c.GetVulnerabilityManifest(context.Background(), "kubescape", "any-name")
+	if err == nil {
+		t.Fatalf("expected error for namespace-not-found 404, got nil with vm=%+v", vm)
+	}
+	if vm != nil {
+		t.Errorf("expected nil manifest, got %+v", vm)
+	}
+}
+
+// TestGetVulnerabilityManifest_NameMismatchIsError defends against a
+// crafted Status whose details.name doesn't match what we asked for.
+// Treat as broken because we did not get a definitive "the named
+// object is missing" answer about THIS object.
+func TestGetVulnerabilityManifest_NameMismatchIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(notFoundStatusJSON("vulnerabilitymanifests", "different-name")))
+	}))
+	defer srv.Close()
+
+	c := NewRESTClient(srv.URL, StaticTokenSource("test-token"))
+
+	vm, err := c.GetVulnerabilityManifest(context.Background(), "kubescape", "asked-for-this-one")
+	if err == nil {
+		t.Fatalf("expected error when 404 names a different object, got nil with vm=%+v", vm)
+	}
+	if vm != nil {
+		t.Errorf("expected nil manifest, got %+v", vm)
 	}
 }
 
@@ -361,7 +464,9 @@ func TestPing_NotFoundIsHealthy(t *testing.T) {
 	var seenPath atomic.Value
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		seenPath.Store(r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(notFoundStatusJSON("vulnerabilitymanifests", readinessProbeName)))
 	}))
 	defer srv.Close()
 
@@ -411,7 +516,9 @@ func TestPing_ProbesVulnerabilityManifestPath(t *testing.T) {
 	var seenPath atomic.Value
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		seenPath.Store(r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(notFoundStatusJSON("vulnerabilitymanifests", readinessProbeName)))
 	}))
 	defer srv.Close()
 
@@ -424,5 +531,45 @@ func TestPing_ProbesVulnerabilityManifestPath(t *testing.T) {
 	wantPrefix := "/apis/spdx.softwarecomposition.kubescape.io/v1beta1/namespaces/myns/vulnerabilitymanifests/"
 	if !strings.HasPrefix(path, wantPrefix) {
 		t.Errorf("Ping URL = %q, want prefix %q", path, wantPrefix)
+	}
+}
+
+// TestPing_BareNotFoundIsUnhealthy pins the headline of issue #37 for the
+// readiness path: a 404 with no Kubernetes Status body (e.g. unserved
+// resource type, broken aggregator, the apiserver doesn't know about the
+// CRD) must take the pod NotReady. Pre-#37 we accepted any 404 as
+// healthy, so a misconfigured cluster could silently keep serving 500s
+// to Harbor while the probe stayed green.
+func TestPing_BareNotFoundIsUnhealthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.NotFound(w, &http.Request{}) // text/plain "404 page not found"
+	}))
+	defer srv.Close()
+
+	c := NewRESTClient(srv.URL, StaticTokenSource("test-token"))
+
+	err := c.Ping(context.Background(), "kubescape")
+	if err == nil {
+		t.Fatal("expected Ping to fail on a bare 404; broken-path conditions must surface as NotReady")
+	}
+}
+
+// TestPing_NamespaceNotFoundIsUnhealthy covers the other broad-404 case
+// from #37: when KUBEVULN_NAMESPACE doesn't exist, K8s returns a Status
+// with details.kind=namespaces. We must NOT treat that as proof the
+// adapter can serve scans.
+func TestPing_NamespaceNotFoundIsUnhealthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(notFoundStatusJSON("namespaces", "kubescape")))
+	}))
+	defer srv.Close()
+
+	c := NewRESTClient(srv.URL, StaticTokenSource("test-token"))
+
+	err := c.Ping(context.Background(), "kubescape")
+	if err == nil {
+		t.Fatal("expected Ping to fail when the namespace itself is missing; readiness must not stay green")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #37 — both \`GetVulnerabilityManifest\` and \`Ping\` treated *any* 404 from the K8s API as benign. Kubernetes returns 404 for several distinct shapes:

| Shape | Meaning | Old behavior | Should be |
|---|---|---|---|
| Status with \`details.kind=vulnerabilitymanifests\` + matching name | Named object missing | benign | benign ✓ |
| Status with \`details.kind=namespaces\` | Namespace doesn't exist | benign 🔴 | error |
| Status with no \`details\` / bare HTTP 404 | Resource unserved / broken aggregator | benign 🔴 | error |
| Status with mismatched \`details.name\` | Crafted / unexpected | benign 🔴 | error |

Net effect of the old behavior:

- \`/probe/ready\` stayed green even with wrong \`KUBEVULN_NAMESPACE\`, missing CRD, or broken aggregator — Harbor kept getting 500s while the pod was Ready.
- \`GetVulnerabilityManifest\` silently returned \`(nil, nil)\` for broken paths, so the controller polled until \`pollTimeout\` (10 min) instead of failing the scan immediately.

## Approach

Add \`isNamedObjectNotFound(body, resource, name)\` that parses the K8s \`Status\` response and returns true **only** when all four signals match: \`Kind=Status\`, \`Reason=NotFound\`, \`Details.Kind\` matches the resource, \`Details.Name\` matches the requested name. Anything else → error.

\`GetVulnerabilityManifest\` and \`Ping\` both use it.

## Tests

For \`GetVulnerabilityManifest\`:
- \`NamedObjectNotFoundIsBenign\` — proper Status → \`(nil, nil)\`.
- \`BareNotFoundIsError\` — \`http.NotFound\` text → error.
- \`NamespaceNotFoundIsError\` — Status with \`details.kind=namespaces\` → error.
- \`NameMismatchIsError\` — Status whose \`details.name\` differs → error.

For \`Ping\`:
- \`NotFoundIsHealthy\` (updated) — proper Status for the probe name → still healthy.
- \`BareNotFoundIsUnhealthy\` — bare 404 → error.
- \`NamespaceNotFoundIsUnhealthy\` — Status with \`details.kind=namespaces\` → error. **Pre-#37 this would have stayed green.**

Test helper \`notFoundStatusJSON\` marshals a real map so the JSON is correctly quoted.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` passes including the new cases.
- [ ] End-to-end on a cluster:
  - Wrong \`KUBEVULN_NAMESPACE\` → pod becomes NotReady (would have stayed Ready before).
  - CRD uninstalled → pod becomes NotReady (would have stayed Ready before).
  - Normal operation, no scan yet for an image → controller keeps polling, pod stays Ready (unchanged).