### PR TITLE
fix(redis): stamp TerminalAt on terminal UpdateStatus calls

### DIFF
--- a/pkg/persistence/redis/store.go
+++ b/pkg/persistence/redis/store.go
@@ -116,6 +116,15 @@ func (s *Store) UpdateStatus(ctx context.Context, id string, status persistence.
 	if len(errMsg) > 0 {
 		job.Error = errMsg[0]
 	}
+	// Mirror the memory store: stamp TerminalAt on terminal transitions
+	// so the documented ScanJob.TerminalAt contract holds across both
+	// backends. Redis itself uses EXPIRE for retention so this isn't
+	// load-bearing for storage today, but any future reader of the
+	// field (e.g. analytics, debug log, a future Stats endpoint) needs
+	// it populated regardless of backend.
+	if status == persistence.Finished || status == persistence.Failed {
+		job.TerminalAt = time.Now()
+	}
 	return s.save(ctx, job)
 }
 

--- a/pkg/persistence/redis/store_test.go
+++ b/pkg/persistence/redis/store_test.go
@@ -253,3 +253,47 @@ func TestSetFinished_NotFound(t *testing.T) {
 		t.Error("expected SetFinished on missing key to error")
 	}
 }
+
+// TestUpdateStatus_SetsTerminalAt pins parity with the memory backend:
+// when UpdateStatus moves a job to Finished or Failed, the timestamp
+// must be set. Pre-fix the Redis path skipped it, leaving terminal jobs
+// with zero TerminalAt — inconsistent with the documented contract on
+// ScanJob.TerminalAt and breaking any future reader that relies on it.
+func TestUpdateStatus_SetsTerminalAt(t *testing.T) {
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	for _, st := range []persistence.ScanJobStatus{persistence.Finished, persistence.Failed} {
+		t.Run(st.String(), func(t *testing.T) {
+			id := "job-" + st.String()
+			if err := s.Create(ctx, persistence.ScanJob{ID: id, Status: persistence.Queued}); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			before := time.Now()
+			if err := s.UpdateStatus(ctx, id, st); err != nil {
+				t.Fatalf("UpdateStatus: %v", err)
+			}
+			after := time.Now()
+
+			got, _ := s.Get(ctx, id)
+			if got.TerminalAt.IsZero() {
+				t.Errorf("%s: TerminalAt is zero, want non-zero", st)
+			}
+			if got.TerminalAt.Before(before) || got.TerminalAt.After(after) {
+				t.Errorf("%s: TerminalAt %v outside expected window [%v, %v]", st, got.TerminalAt, before, after)
+			}
+		})
+	}
+
+	// Non-terminal transitions must NOT set TerminalAt.
+	if err := s.Create(ctx, persistence.ScanJob{ID: "job-pending", Status: persistence.Queued}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := s.UpdateStatus(ctx, "job-pending", persistence.Pending); err != nil {
+		t.Fatalf("UpdateStatus Pending: %v", err)
+	}
+	got, _ := s.Get(ctx, "job-pending")
+	if !got.TerminalAt.IsZero() {
+		t.Errorf("Pending must not set TerminalAt, got %v", got.TerminalAt)
+	}
+}


### PR DESCRIPTION
## Summary

The memory store's \`UpdateStatus\` sets \`TerminalAt\` when the job transitions to \`Finished\` or \`Failed\`; the Redis store's didn't. Documented contract on \`ScanJob.TerminalAt\` was therefore backend-dependent — a future reader (analytics, debug log, retention metrics) that relied on it would silently see zero for Redis.

## Fix

One-line mirror of the memory store's check:

\`\`\`go
if status == persistence.Finished || status == persistence.Failed {
    job.TerminalAt = time.Now()
}
\`\`\`

## Test

\`TestUpdateStatus_SetsTerminalAt\` — pins both terminal transitions (Finished, Failed) plus the negative case (Pending must not stamp).