### PR TITLE
fix(handler): set Content-Type before WriteHeader; drop bogus Refresh-After

### DIFF
--- a/pkg/http/api/v1/handler.go
+++ b/pkg/http/api/v1/handler.go
@@ -236,13 +236,15 @@ func (h *requestHandler) GetScanReport(w http.ResponseWriter, r *http.Request) {
 
 	switch job.Status {
 	case persistence.Queued, persistence.Pending:
-		// Scan is still in progress - return 302 so Harbor retries
+		// Scan is still in progress - return 302 so Harbor retries.
+		// Harbor's scanner-spec client polls on its own schedule, so we
+		// don't need a Refresh hint; the prior `Refresh-After` header
+		// wasn't a real HTTP header anyway.
 		slog.Debug("Scan in progress",
 			slog.String("scan_job_id", scanJobID),
 			slog.String("status", job.Status.String()),
 		)
 		w.Header().Set("Location", r.URL.String())
-		w.Header().Set("Refresh-After", "5")
 		w.WriteHeader(http.StatusFound)
 		return
 
@@ -285,6 +287,7 @@ func (h *requestHandler) GetReady(w http.ResponseWriter, _ *http.Request) {
 		}
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	if allOK {
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "checks": results})
@@ -292,7 +295,6 @@ func (h *requestHandler) GetReady(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	slog.Warn("Readiness check failed", slog.Any("checks", results))
-	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusServiceUnavailable)
 	_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "checks": results})
 }

--- a/pkg/http/api/v1/handler_test.go
+++ b/pkg/http/api/v1/handler_test.go
@@ -171,6 +171,15 @@ func TestGetScanReport_Pending(t *testing.T) {
 	if w.Code != http.StatusFound {
 		t.Fatalf("expected 302, got %d", w.Code)
 	}
+	// Guard against resurrecting the bogus Refresh-After header. Harbor's
+	// scanner client polls on its own schedule and ignores it; the name
+	// isn't a real HTTP header anyway.
+	if got := w.Header().Get("Refresh-After"); got != "" {
+		t.Errorf("Refresh-After header should not be set, got %q", got)
+	}
+	if got := w.Header().Get("Location"); got == "" {
+		t.Errorf("Location header should still be set on 302, got empty")
+	}
 }
 
 func TestGetScanReport_Finished(t *testing.T) {
@@ -400,8 +409,11 @@ func TestAcceptScanRequest_GoroutineRespectsScanCtx(t *testing.T) {
 	}
 }
 
-// TestReady_AllChecksPass confirms the all-pass path returns 200 and lists
-// each successful check by name.
+// TestReady_AllChecksPass confirms the all-pass path returns 200, lists
+// each successful check by name, AND advertises Content-Type:
+// application/json. Pre-fix the success path called WriteHeader before
+// setting Content-Type, so the header was silently dropped — anything
+// that tried to parse the JSON body got text/plain.
 func TestReady_AllChecksPass(t *testing.T) {
 	handler := NewAPIHandler(
 		config.BuildInfo{}, config.Config{}, memory.NewStore(), nil,
@@ -416,5 +428,8 @@ func TestReady_AllChecksPass(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json (header order regression)", got)
 	}
 }


### PR DESCRIPTION
## Summary

Two small handler cleanups from the post-#37 audit:

1. **\`/probe/ready\` success path** called \`WriteHeader\` before \`Header().Set(\"Content-Type\", ...)\`, so the JSON Content-Type was silently dropped. Anything that tried to parse the body got \`text/plain\`. K8s probes only check status so this was invisible to readiness, but any HTTP client trying to introspect the response got broken parsing. Matches the 503 branch and the rest of the handler now.

2. **\`GetScanReport\` 302 set \`Refresh-After: 5\`** — that isn't a real HTTP header. The closest standard-ish thing is \`Refresh: 5\` (a non-standard browser hint), but Harbor's scanner client polls on its own schedule and ignores both. Drop the misnamed clutter. \`Location\` stays — that one's used by the harbor-scanner-trivy reference impl.

## Tests

- \`TestReady_AllChecksPass\` — now also asserts \`Content-Type: application/json\` on the success path. **Would fail under the previous code** (header dropped due to ordering).
- \`TestGetScanReport_Pending\` — guards against the bogus header coming back; confirms \`Location\` is still set.