### PR TITLE
fix(controller): bail fast on fatal K8s API errors

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -2,10 +2,22 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 )
+
+// ErrFatalAPIRead indicates a Kubernetes API failure that won't recover by
+// retrying within a single scan: token rejected (401/403), or a 404 that
+// names something other than the requested object (missing namespace,
+// unserved resource type, broken aggregator). Callers — most importantly
+// the scan controller's poll loop — should short-circuit on this rather
+// than burn the full pollTimeout retrying. Network blips and 5xx are NOT
+// fatal; those keep retrying.
+//
+// Use errors.Is(err, k8s.ErrFatalAPIRead) to detect.
+var ErrFatalAPIRead = errors.New("kubernetes API read is unrecoverable without operator action")
 
 // VulnerabilityManifest is a transformer-friendly projection of the
 // kubescape/storage v1beta1.VulnerabilityManifest CRD. The REST client

--- a/pkg/k8s/rest_client.go
+++ b/pkg/k8s/rest_client.go
@@ -170,11 +170,22 @@ func (c *RESTClient) GetVulnerabilityManifest(ctx context.Context, namespace, na
 		// resource path, or a broken aggregator must surface as an error
 		// — otherwise GetVulnerabilityManifest silently returns "no scan
 		// result yet" and the controller polls until timeout instead of
-		// failing fast. See issue #37.
+		// failing fast. See issue #37. The non-benign branch is wrapped
+		// with ErrFatalAPIRead so the poll loop can short-circuit
+		// instead of retrying for 10 minutes against a misconfigured
+		// cluster.
 		if isNamedObjectNotFound(body, resource, name) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("K8s API 404 not for the requested object (likely missing namespace, unserved resource type, or broken path): %s", string(body))
+		return nil, fmt.Errorf("%w: K8s API 404 not for the requested object (likely missing namespace, unserved resource type, or broken path): %s", ErrFatalAPIRead, string(body))
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		// Auth failure won't recover within a single scan. Token rotation
+		// is picked up on the next request, so a transient 401 right at
+		// rotation boundary would flap at most once — but in steady state
+		// 401/403 means RBAC / token misconfig, and retrying for the
+		// full pollTimeout is a waste of budget.
+		return nil, fmt.Errorf("%w: K8s API rejected GET (HTTP %d): %s", ErrFatalAPIRead, resp.StatusCode, string(body))
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("K8s API returned %d: %s", resp.StatusCode, string(body))
@@ -279,9 +290,9 @@ func (c *RESTClient) Ping(ctx context.Context, namespace string) error {
 		if isNamedObjectNotFound(body, resource, readinessProbeName) {
 			return nil
 		}
-		return fmt.Errorf("k8s API 404 not for the probe object (likely missing namespace, unserved resource type, or broken path): %s", string(body))
+		return fmt.Errorf("%w: k8s API 404 not for the probe object (likely missing namespace, unserved resource type, or broken path): %s", ErrFatalAPIRead, string(body))
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return fmt.Errorf("k8s API rejected VulnerabilityManifest GET (HTTP %d) — likely token rotation not picked up or RBAC missing", resp.StatusCode)
+		return fmt.Errorf("%w: k8s API rejected VulnerabilityManifest GET (HTTP %d) — likely token rotation not picked up or RBAC missing", ErrFatalAPIRead, resp.StatusCode)
 	default:
 		return fmt.Errorf("k8s API ping returned %d: %s", resp.StatusCode, string(body))
 	}

--- a/pkg/scan/controller.go
+++ b/pkg/scan/controller.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -144,6 +145,13 @@ func (c *controller) scan(ctx context.Context, scanJobID string) error {
 	var staleSeenAt time.Time
 
 	if err != nil {
+		// Bail fast on unrecoverable errors (auth rejection, missing
+		// namespace, unserved resource type). Triggering a kubevuln
+		// scan we can't observe would just burn the pollTimeout
+		// budget for nothing.
+		if errors.Is(err, k8s.ErrFatalAPIRead) {
+			return fmt.Errorf("aborting scan on unrecoverable K8s API error: %w", err)
+		}
 		slog.Warn("Failed to check existing VulnerabilityManifest, will trigger new scan",
 			slog.String("err", err.Error()),
 		)
@@ -237,7 +245,14 @@ func (c *controller) pollForResults(ctx context.Context, crdName string, artifac
 
 			vm, err := c.k8sClient.GetVulnerabilityManifest(ctx, c.namespace, crdName)
 			if err != nil {
-				slog.Warn("Error polling VulnerabilityManifest",
+				// Unrecoverable errors (auth rejection, missing namespace,
+				// broken resource path) won't fix themselves. Bail
+				// immediately instead of burning the rest of pollTimeout
+				// retrying against a misconfigured cluster.
+				if errors.Is(err, k8s.ErrFatalAPIRead) {
+					return harbor.ScanReport{}, fmt.Errorf("aborting poll on unrecoverable K8s API error: %w", err)
+				}
+				slog.Warn("Error polling VulnerabilityManifest (transient, will retry)",
 					slog.String("crd_name", crdName),
 					slog.String("err", err.Error()),
 				)

--- a/pkg/scan/controller_test.go
+++ b/pkg/scan/controller_test.go
@@ -3,6 +3,7 @@ package scan
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -477,5 +478,98 @@ func TestScan_RedisFailedWrite_UsesUncancelledCtx(t *testing.T) {
 	}
 	if got.Error == "" {
 		t.Errorf("expected job.Error to be populated, got empty string")
+	}
+}
+
+// fatalErrK8sClient simulates a K8s client that always returns
+// k8s.ErrFatalAPIRead — e.g. a cluster where RBAC is misconfigured or
+// the namespace is wrong.
+type fatalErrK8sClient struct {
+	calls int
+}
+
+func (f *fatalErrK8sClient) GetVulnerabilityManifest(_ context.Context, _, _ string) (*k8s.VulnerabilityManifest, error) {
+	f.calls++
+	return nil, fmt.Errorf("test: %w", k8s.ErrFatalAPIRead)
+}
+
+func (f *fatalErrK8sClient) ListVulnerabilityManifests(_ context.Context, _, _ string) ([]k8s.VulnerabilityManifest, error) {
+	return nil, nil
+}
+
+func (f *fatalErrK8sClient) Ping(_ context.Context, _ string) error { return nil }
+
+// TestScan_FatalAPIError_BailsImmediately pins the fail-fast contract on
+// k8s.ErrFatalAPIRead: when the initial CRD check returns an unrecoverable
+// error (auth rejection, missing namespace, broken path), the controller
+// must NOT trigger a kubevuln scan and then poll for 10 minutes against
+// a cluster that will never produce a result. It must record Failed
+// status immediately.
+func TestScan_FatalAPIError_BailsImmediately(t *testing.T) {
+	store := memory.NewStore()
+	ctx := context.Background()
+
+	job := persistence.ScanJob{
+		ID: "job-fatal-init",
+		Request: harbor.ScanRequest{
+			Registry: harbor.Registry{URL: "https://core.harbor.domain"},
+			Artifact: harbor.Artifact{
+				Repository: "library/nginx",
+				Digest:     "sha256:abcdef0123456789",
+			},
+		},
+		Status: persistence.Queued,
+	}
+	if err := store.Create(ctx, job); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	fakeK8s := &fatalErrK8sClient{}
+	scanner := &fakeScanner{}
+
+	c := NewController(store, scanner, fakeK8s, "kubescape", DefaultReuseTTL)
+	err := c.Scan(ctx, job.ID)
+	if err == nil {
+		t.Fatal("expected Scan to fail with the fatal API error, got nil")
+	}
+	if !errors.Is(err, k8s.ErrFatalAPIRead) {
+		t.Errorf("expected error to wrap k8s.ErrFatalAPIRead, got %v", err)
+	}
+
+	// Critically, scanner.TriggerScan must NOT have been called: we should
+	// have bailed before kicking off a kubevuln scan we can't observe.
+	if scanner.triggers != 0 {
+		t.Errorf("scanner.triggers = %d, want 0 — controller must bail before triggering kubevuln on fatal API error", scanner.triggers)
+	}
+
+	got, _ := store.Get(ctx, job.ID)
+	if got.Status != persistence.Failed {
+		t.Errorf("expected status Failed, got %s", got.Status)
+	}
+}
+
+// TestPollForResults_FatalAPIError_Aborts pins the same fail-fast contract
+// for the poll path: if the K8s client starts returning a fatal API error
+// during polling (e.g. RBAC revoked mid-scan), the loop must abort
+// immediately rather than spam the API for the full pollTimeout.
+func TestPollForResults_FatalAPIError_Aborts(t *testing.T) {
+	pollInterval = 5 * time.Millisecond
+	t.Cleanup(func() { pollInterval = 5 * time.Second })
+
+	fakeK8s := &fatalErrK8sClient{}
+	c := &controller{k8sClient: fakeK8s, namespace: "kubescape"}
+
+	_, err := c.pollForResults(context.Background(), "any-name", harbor.Artifact{}, time.Time{})
+	if err == nil {
+		t.Fatal("expected pollForResults to error, got nil")
+	}
+	if !errors.Is(err, k8s.ErrFatalAPIRead) {
+		t.Errorf("expected error to wrap k8s.ErrFatalAPIRead, got %v", err)
+	}
+	// Should have bailed within a few ticks, NOT looped for the full
+	// pollTimeout. The fakeK8sClient counts; one or two calls is fine,
+	// dozens means the abort path didn't fire.
+	if fakeK8s.calls > 3 {
+		t.Errorf("fakeK8s.calls = %d, want ≤3 — poll loop kept retrying despite fatal error", fakeK8s.calls)
 	}
 }


### PR DESCRIPTION
## Summary

After #37 narrowed 404 handling, \`GetVulnerabilityManifest\` correctly errors on broken-path conditions (missing namespace, unserved CRD, auth rejection). The controller's poll loop and initial CRD check, however, retried on **any** error — for the full 10-minute \`pollTimeout\` — even when no amount of retrying would make the config suddenly work.

## Approach

New typed sentinel \`k8s.ErrFatalAPIRead\` distinguishes unrecoverable from transient errors:

| Condition | Sentinel? | Poll behavior |
|---|---|---|
| 401 / 403 (auth) | wrapped | abort immediately |
| 404 not for the requested object (missing ns / unserved CRD) | wrapped | abort immediately |
| Network errors, 5xx, ctx cancel | NOT wrapped | keep retrying (transient) |

\`Get\` and \`Ping\` wrap the right paths; the controller's initial check and poll loop both \`errors.Is(err, k8s.ErrFatalAPIRead)\` and short-circuit.

Net effect: misconfigured cluster surfaces \`Failed\` in seconds instead of 10 minutes, AND we no longer kick off a kubevuln scan we couldn't have observed anyway.

## Tests

- **\`TestScan_FatalAPIError_BailsImmediately\`** — fake client always returns \`ErrFatalAPIRead\`. Asserts: scan ends \`Failed\` promptly, \`scanner.TriggerScan\` is NOT called (no wasted kubevuln work), error wraps the sentinel.
- **\`TestPollForResults_FatalAPIError_Aborts\`** — same fake, poll path. Counts client calls — must be a small constant, not \`pollTimeout/pollInterval\` calls.