### PR TITLE
fix: bound HTTP body sizes and tighten kubevuln client timeout

### DIFF
--- a/pkg/http/api/v1/handler.go
+++ b/pkg/http/api/v1/handler.go
@@ -28,6 +28,14 @@ const (
 
 	mimeTypeOCIManifest    = "application/vnd.oci.image.manifest.v1+json"
 	mimeTypeDockerManifest = "application/vnd.docker.distribution.manifest.v2+json"
+
+	// maxScanRequestBodyBytes caps how much of the POST /api/v1/scan body
+	// we will read into memory. Harbor's scan request is a tiny JSON
+	// document (registry URL + artifact digest + maybe a credentials
+	// header); 1 MiB is well over what's plausibly legit and stops a
+	// hostile / misbehaving Harbor instance from OOMing the pod with a
+	// huge body.
+	maxScanRequestBodyBytes = 1 * 1024 * 1024
 )
 
 // ReadinessCheck returns nil when the named subsystem is ready to serve scan
@@ -153,6 +161,10 @@ func (h *requestHandler) GetMetadata(w http.ResponseWriter, _ *http.Request) {
 
 // AcceptScanRequest accepts a scan request from Harbor, enqueues it, and returns a scan ID.
 func (h *requestHandler) AcceptScanRequest(w http.ResponseWriter, r *http.Request) {
+	// Bound the request body so a hostile / misbehaving caller can't OOM
+	// the pod with an unbounded POST. Harbor's scan request is tiny in
+	// practice; 1 MiB is well above any plausible legit value.
+	r.Body = http.MaxBytesReader(w, r.Body, maxScanRequestBodyBytes)
 	var scanRequest harbor.ScanRequest
 	if err := json.NewDecoder(r.Body).Decode(&scanRequest); err != nil {
 		slog.Error("Failed to decode scan request", slog.String("err", err.Error()))

--- a/pkg/http/api/v1/handler_test.go
+++ b/pkg/http/api/v1/handler_test.go
@@ -140,6 +140,31 @@ func TestAcceptScanRequest_MissingFields(t *testing.T) {
 	}
 }
 
+// TestAcceptScanRequest_OversizeBody pins the bounded-body guard: a POST
+// with a body well over the cap must be rejected, not silently consume
+// all that memory before parsing.
+func TestAcceptScanRequest_OversizeBody(t *testing.T) {
+	store := memory.NewStore()
+	handler := NewAPIHandler(config.BuildInfo{}, config.Config{}, store, nil, nil, nil)
+
+	// 2 MiB of nonsense — twice the cap. Encoded as a JSON string so the
+	// decoder reads it as a single token before deciding it's not a valid
+	// ScanRequest. With the cap, MaxBytesReader cuts it short and the
+	// decode errors out at 400 BadRequest.
+	huge := bytes.Repeat([]byte("x"), maxScanRequestBodyBytes+maxScanRequestBodyBytes)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/scan", bytes.NewReader(huge))
+	req.ContentLength = int64(len(huge))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code == http.StatusAccepted {
+		t.Fatalf("oversize body should NOT be accepted, got 202")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for oversize body, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestGetScanReport_NotFound(t *testing.T) {
 	store := memory.NewStore()
 	handler := NewAPIHandler(config.BuildInfo{}, config.Config{}, store, nil, nil, nil)

--- a/pkg/k8s/rest_client.go
+++ b/pkg/k8s/rest_client.go
@@ -116,7 +116,31 @@ const (
 	apiGroup   = "spdx.softwarecomposition.kubescape.io"
 	apiVersion = "v1beta1"
 	resource   = "vulnerabilitymanifests"
+
+	// maxResponseBodyBytes caps how much of any single K8s API response we
+	// will read into memory. VulnerabilityManifest CRDs can be large
+	// (thousands of matches × CWE/CVSS entries) but should never approach
+	// this — 8 MiB is comfortable headroom and a hostile / runaway response
+	// can't OOM the pod. Default kube-apiserver MaxRequestBodySize is 100
+	// MiB, so we are well under.
+	maxResponseBodyBytes = 8 * 1024 * 1024
 )
+
+// readBodyCapped reads at most maxResponseBodyBytes from r. If the limit
+// is hit we return an explicit error rather than a silently-truncated body
+// — a partial Status JSON would parse as garbage and confuse the 404
+// classification (issue #37).
+func readBodyCapped(r io.Reader) ([]byte, error) {
+	limited := io.LimitReader(r, maxResponseBodyBytes+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxResponseBodyBytes {
+		return nil, fmt.Errorf("response body exceeds %d bytes", maxResponseBodyBytes)
+	}
+	return body, nil
+}
 
 // cweOverlay captures CWE-related fields the canonical v1beta1 type does not
 // (yet) carry. It is decoded from the same response body as the canonical
@@ -159,7 +183,7 @@ func (c *RESTClient) GetVulnerabilityManifest(ctx context.Context, namespace, na
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := readBodyCapped(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading VulnerabilityManifest: %w", err)
 	}
@@ -213,12 +237,16 @@ func (c *RESTClient) ListVulnerabilityManifests(ctx context.Context, namespace, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := readBodyCapped(resp.Body)
 		return nil, fmt.Errorf("K8s API returned %d: %s", resp.StatusCode, string(body))
 	}
 
+	body, err := readBodyCapped(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading VulnerabilityManifest list: %w", err)
+	}
 	var list v1beta1.VulnerabilityManifestList
-	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+	if err := json.Unmarshal(body, &list); err != nil {
 		return nil, fmt.Errorf("decoding VulnerabilityManifest list: %w", err)
 	}
 
@@ -264,7 +292,7 @@ func (c *RESTClient) Ping(ctx context.Context, namespace string) error {
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, _ := readBodyCapped(resp.Body)
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/pkg/scan/scanner.go
+++ b/pkg/scan/scanner.go
@@ -37,11 +37,22 @@ func NewScanner(cfg config.KubevulnConfig) Scanner {
 	return &kubevulnScanner{
 		kubevulnURL: strings.TrimRight(cfg.URL, "/"),
 		namespace:   cfg.Namespace,
+		// Tight timeout: kubevuln's TriggerScan is documented as async —
+		// it accepts the request and returns immediately. The actual scan
+		// progress is observed by polling the VulnerabilityManifest CRD
+		// (controller.pollForResults). A 30s budget catches handshake +
+		// scheduling latency without pinning a goroutine for ten minutes
+		// against a hung kubevuln.
 		httpClient: &http.Client{
-			Timeout: 10 * time.Minute,
+			Timeout: 30 * time.Second,
 		},
 	}
 }
+
+// maxKubevulnResponseBytes caps how much of kubevuln's TriggerScan response
+// we'll read. The response is a small ack body — 64 KiB is generous, and
+// stops a hostile / misbehaving kubevuln from streaming us into OOM.
+const maxKubevulnResponseBytes = 64 * 1024
 
 // kubevulnScanRequest is the WebsocketScanCommand-compatible request for kubevuln.
 type kubevulnScanRequest struct {
@@ -110,7 +121,7 @@ func (s *kubevulnScanner) TriggerScan(ctx context.Context, req harbor.ScanReques
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxKubevulnResponseBytes))
 		return fmt.Errorf("kubevuln returned %d: %s", resp.StatusCode, string(respBody))
 	}
 


### PR DESCRIPTION
## Summary

Defense-in-depth hardening of the HTTP plumbing — three small unrelated cleanups grouped because they're all about \"don't let untrusted input or hung peers eat resources.\"

| Change | Before | After |
|---|---|---|
| K8s API response bodies | unbounded \`io.ReadAll\` | 8 MiB cap via \`readBodyCapped\` |
| kubevuln response bodies | unbounded | 64 KiB cap |
| kubevuln client \`Timeout\` | 10 minutes | 30 seconds (TriggerScan is async) |
| \`POST /api/v1/scan\` body | unbounded | 1 MiB cap via \`http.MaxBytesReader\` |

## Notes

- The 8 MiB k8s response cap is well over what any plausible \`VulnerabilityManifest\` carries (thousands of matches × CWE/CVSS entries) and well under kube-apiserver's 100 MiB default.
- The 30s kubevuln timeout was chosen to cover handshake + scheduling latency. Per kubevuln's documented behavior, \`TriggerScan\` ACKs immediately — the actual scan runs async and we observe progress via CRD polling.
- The cap on response bodies is enforced as **explicit error** rather than silent truncation. A truncated Status JSON would parse as garbage and confuse the #37 404 classification.

## Test

- \`TestAcceptScanRequest_OversizeBody\` — POSTs a 2 MiB body, asserts the handler rejects it (not 202).