### PR TITLE
fix(transformer): pick highest CVSS score; clean reports stay Negligible

### DIFF
--- a/pkg/scan/transformer.go
+++ b/pkg/scan/transformer.go
@@ -42,17 +42,25 @@ func TransformManifestToReport(vm *k8s.VulnerabilityManifest, artifact harbor.Ar
 			CweIDs:      m.CweIDs,
 		}
 
-		// Map CVSS if available
+		// Map CVSS — pick the HIGHEST base score per version. Grype can
+		// emit multiple CVSS entries (NVD + vendor + RedHat) for the
+		// same CVE; the previous "last entry wins" was deterministic
+		// but order-dependent and could quietly understate severity if
+		// the vendor's score happened to come last. Prefer worst-case.
 		if len(m.CVSS) > 0 {
 			cvss := &harbor.CVSSDetails{}
 			for _, c := range m.CVSS {
 				score := float32(c.BaseScore)
 				if strings.HasPrefix(c.Version, "3") {
-					cvss.ScoreV3 = &score
-					cvss.VectorV3 = c.Vector
+					if cvss.ScoreV3 == nil || score > *cvss.ScoreV3 {
+						cvss.ScoreV3 = &score
+						cvss.VectorV3 = c.Vector
+					}
 				} else if strings.HasPrefix(c.Version, "2") {
-					cvss.ScoreV2 = &score
-					cvss.VectorV2 = c.Vector
+					if cvss.ScoreV2 == nil || score > *cvss.ScoreV2 {
+						cvss.ScoreV2 = &score
+						cvss.VectorV2 = c.Vector
+					}
 				}
 			}
 			item.CVSS = cvss
@@ -61,11 +69,18 @@ func TransformManifestToReport(vm *k8s.VulnerabilityManifest, artifact harbor.Ar
 		report.Vulnerabilities = append(report.Vulnerabilities, item)
 	}
 
-	report.Severity = highestSeverity
-
-	// Ensure non-nil slice for JSON serialization
-	if report.Vulnerabilities == nil {
+	// Overall severity. Two cases:
+	//   * non-empty manifest → highest severity across matches
+	//   * empty manifest     → SevNegligible. Pre-fix this stayed at the
+	//     zero value, which the Severity.MarshalJSON fallback emits as
+	//     "Unknown" — confusing for a clean image. Negligible is the
+	//     lowest enum the Harbor scanner spec recognises and accurately
+	//     conveys "scanned, nothing noteworthy."
+	if len(report.Vulnerabilities) == 0 {
+		report.Severity = harbor.SevNegligible
 		report.Vulnerabilities = []harbor.VulnerabilityItem{}
+	} else {
+		report.Severity = highestSeverity
 	}
 
 	return report

--- a/pkg/scan/transformer_test.go
+++ b/pkg/scan/transformer_test.go
@@ -130,6 +130,57 @@ func TestTransformManifestToReport_Empty(t *testing.T) {
 	if report.Vulnerabilities == nil {
 		t.Error("expected non-nil vulnerabilities slice for JSON serialization")
 	}
+	// Clean image must report Negligible — pre-fix it stayed at the zero
+	// value and serialized as "Unknown" via the Severity.MarshalJSON
+	// fallback, which is misleading for a scanned-and-clean image.
+	if report.Severity != harbor.SevNegligible {
+		t.Errorf("clean image severity = %s, want Negligible (zero/Unknown was the pre-fix bug)", report.Severity)
+	}
+}
+
+// TestTransformManifestToReport_PicksHighestCVSS pins the CVSS-multi-entry
+// behavior: when Grype emits multiple v3 entries (NVD + vendor + RedHat),
+// the transformer must pick the HIGHEST score, not the last one in the
+// slice. Pre-fix the loop overwrote unconditionally and the answer
+// depended on emission order.
+func TestTransformManifestToReport_PicksHighestCVSS(t *testing.T) {
+	vm := &k8s.VulnerabilityManifest{
+		Name:      "test",
+		CreatedAt: time.Now(),
+		Matches: []k8s.VulnMatch{{
+			ID:       "CVE-2024-9999",
+			Severity: "High",
+			PkgName:  "libfoo",
+			CVSS: []k8s.VulnCVSS{
+				// Lowest first, highest in the middle, then a lower one.
+				// Pre-fix the last (3.5) would have won; post-fix the 9.8 wins.
+				{Version: "3.1", Vector: "CVSS:3.1/AV:N", BaseScore: 5.5},
+				{Version: "3.1", Vector: "CVSS:3.1/AV:L", BaseScore: 9.8},
+				{Version: "3.1", Vector: "CVSS:3.1/AV:N", BaseScore: 3.5},
+				// Same pattern for v2.
+				{Version: "2.0", Vector: "AV:N/AC:L", BaseScore: 4.0},
+				{Version: "2.0", Vector: "AV:L/AC:H", BaseScore: 8.5},
+			},
+		}},
+	}
+
+	report := TransformManifestToReport(vm, harbor.Artifact{})
+	if len(report.Vulnerabilities) != 1 {
+		t.Fatalf("expected 1 vulnerability, got %d", len(report.Vulnerabilities))
+	}
+	cvss := report.Vulnerabilities[0].CVSS
+	if cvss == nil {
+		t.Fatal("expected CVSS details, got nil")
+	}
+	if cvss.ScoreV3 == nil || *cvss.ScoreV3 != 9.8 {
+		t.Errorf("ScoreV3 = %v, want 9.8 (highest)", cvss.ScoreV3)
+	}
+	if cvss.VectorV3 != "CVSS:3.1/AV:L" {
+		t.Errorf("VectorV3 = %q, want vector for the 9.8 score", cvss.VectorV3)
+	}
+	if cvss.ScoreV2 == nil || *cvss.ScoreV2 != 8.5 {
+		t.Errorf("ScoreV2 = %v, want 8.5 (highest)", cvss.ScoreV2)
+	}
 }
 
 func equalStrings(a, b []string) bool {


### PR DESCRIPTION
## Summary

Two related transformer cleanups from the post-#37 audit:

### 1. CVSS score selection — pick the highest

Grype can emit multiple CVSS v3 (and v2) entries for the same CVE — NVD + vendor + RedHat are common. The previous loop overwrote unconditionally, so the answer depended on emission order. If the vendor's score (often more conservative) came last, it'd silently understate severity.

Pick the **highest** score per version. Worst-case is the defensible default for a security tool.

### 2. Empty manifest → Negligible, not Unknown

A clean image (zero matches) used to leave \`report.Severity\` at the zero value. \`Severity.MarshalJSON\` has a fallback that serialises any unmapped value as \`\"Unknown\"\`. Net effect: a successfully-scanned clean image displayed in Harbor as \"Unknown overall severity,\" which is misleading.

Set \`Severity = SevNegligible\` for empty reports. Negligible is the lowest enum the Harbor scanner spec recognises and accurately conveys \"scanned, nothing noteworthy.\"

## Tests

- **\`TestTransformManifestToReport_Empty\`** — extends existing test to assert \`Severity == SevNegligible\` (would have failed under the old code).
- **\`TestTransformManifestToReport_PicksHighestCVSS\`** — three v3 entries (5.5, 9.8, 3.5) and two v2 entries (4.0, 8.5) in deliberately mixed order; asserts 9.8 and 8.5 win regardless of position.