### PR TITLE
fix(k8s): apply CWE overlay to List as well as Get

### DIFF
--- a/pkg/k8s/rest_client.go
+++ b/pkg/k8s/rest_client.go
@@ -256,6 +256,7 @@ func (c *RESTClient) ListVulnerabilityManifests(ctx context.Context, namespace, 
 	if err != nil {
 		return nil, fmt.Errorf("reading VulnerabilityManifest list: %w", err)
 	}
+
 	var list v1beta1.VulnerabilityManifestList
 	if err := json.Unmarshal(body, &list); err != nil {
 		return nil, fmt.Errorf("decoding VulnerabilityManifest list: %w", err)
@@ -265,6 +266,12 @@ func (c *RESTClient) ListVulnerabilityManifests(ctx context.Context, namespace, 
 	for i := range list.Items {
 		result = append(result, *canonicalToManifest(&list.Items[i]))
 	}
+	// CWE overlay parity with Get: parse the same body again as a
+	// list-shaped overlay to capture cwes that the canonical v1beta1
+	// type doesn't yet carry, then merge by index. See issue #5; this
+	// just extends that fix to the List path so both API surfaces stay
+	// in sync.
+	applyCweOverlayList(body, result)
 	return result, nil
 }
 
@@ -420,12 +427,42 @@ func applyCweOverlay(body []byte, vm *VulnerabilityManifest) {
 	if err := json.Unmarshal(body, &overlay); err != nil {
 		return
 	}
-	n := len(overlay.Spec.Payload.Matches)
-	if n > len(vm.Matches) {
-		n = len(vm.Matches)
+	mergeCwes(overlay.Spec.Payload.Matches, vm.Matches)
+}
+
+// cweOverlayList mirrors a VulnerabilityManifestList response just for the
+// CWE fields. Same shape as cweOverlay but inside an items array.
+type cweOverlayList struct {
+	Items []cweOverlay `json:"items"`
+}
+
+// applyCweOverlayList is the List-path counterpart of applyCweOverlay.
+// Decodes the raw body once as a list-shaped overlay and merges CWEs
+// onto each manifest's Matches by index. Non-fatal on parse failure.
+func applyCweOverlayList(body []byte, manifests []VulnerabilityManifest) {
+	var overlay cweOverlayList
+	if err := json.Unmarshal(body, &overlay); err != nil {
+		return
+	}
+	n := len(overlay.Items)
+	if n > len(manifests) {
+		n = len(manifests)
 	}
 	for i := 0; i < n; i++ {
-		vm.Matches[i].CweIDs = unionCwes(overlay.Spec.Payload.Matches[i])
+		mergeCwes(overlay.Items[i].Spec.Payload.Matches, manifests[i].Matches)
+	}
+}
+
+// mergeCwes is the shared body of applyCweOverlay / applyCweOverlayList:
+// walk both slices by index and stamp the deduped CWE union onto each
+// VulnMatch.
+func mergeCwes(overlay []cweOverlayMatch, matches []VulnMatch) {
+	n := len(overlay)
+	if n > len(matches) {
+		n = len(matches)
+	}
+	for i := 0; i < n; i++ {
+		matches[i].CweIDs = unionCwes(overlay[i])
 	}
 }
 

--- a/pkg/k8s/rest_client_test.go
+++ b/pkg/k8s/rest_client_test.go
@@ -573,3 +573,93 @@ func TestPing_NamespaceNotFoundIsUnhealthy(t *testing.T) {
 		t.Fatal("expected Ping to fail when the namespace itself is missing; readiness must not stay green")
 	}
 }
+
+// TestListVulnerabilityManifests_AppliesCweOverlay pins parity with Get:
+// CWE IDs (which the canonical v1beta1 type doesn't carry) must also
+// surface from List responses. Pre-fix the List path skipped the overlay
+// entirely, so any future caller of List would silently miss CWEs even
+// though Get had them.
+func TestListVulnerabilityManifests_AppliesCweOverlay(t *testing.T) {
+	const listJSON = `{
+	  "apiVersion": "spdx.softwarecomposition.kubescape.io/v1beta1",
+	  "kind": "VulnerabilityManifestList",
+	  "metadata": {},
+	  "items": [
+	    {
+	      "metadata": {
+	        "name": "first",
+	        "namespace": "kubescape",
+	        "creationTimestamp": "2026-04-30T12:00:00Z"
+	      },
+	      "spec": {
+	        "metadata": {"tool":{"name":"grype","version":"0.74.0"}, "report":{"createdAt":"2026-04-30T12:00:00Z"}},
+	        "payload": {
+	          "matches": [
+	            {
+	              "vulnerability": {"id":"CVE-A","severity":"High","cwes":["CWE-79"]},
+	              "relatedVulnerabilities": [{"cwes":["CWE-89"]}],
+	              "artifact": {"name":"libfoo","version":"1.0"}
+	            }
+	          ]
+	        }
+	      }
+	    },
+	    {
+	      "metadata": {
+	        "name": "second",
+	        "namespace": "kubescape",
+	        "creationTimestamp": "2026-04-30T12:00:00Z"
+	      },
+	      "spec": {
+	        "metadata": {"tool":{"name":"grype","version":"0.74.0"}, "report":{"createdAt":"2026-04-30T12:00:00Z"}},
+	        "payload": {
+	          "matches": [
+	            {
+	              "vulnerability": {"id":"CVE-B","severity":"Low"},
+	              "relatedVulnerabilities": [{"cwes":["CWE-200"]}],
+	              "artifact": {"name":"libbar","version":"2.0"}
+	            }
+	          ]
+	        }
+	      }
+	    }
+	  ]
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listJSON))
+	}))
+	defer srv.Close()
+
+	c := NewRESTClient(srv.URL, StaticTokenSource("test-token"))
+
+	manifests, err := c.ListVulnerabilityManifests(context.Background(), "kubescape", "")
+	if err != nil {
+		t.Fatalf("ListVulnerabilityManifests: %v", err)
+	}
+	if len(manifests) != 2 {
+		t.Fatalf("expected 2 manifests, got %d", len(manifests))
+	}
+
+	// First manifest: CWEs from both vulnerability.cwes and
+	// relatedVulnerabilities.cwes, deduplicated and ordered first-seen.
+	if len(manifests[0].Matches) != 1 {
+		t.Fatalf("first manifest: expected 1 match, got %d", len(manifests[0].Matches))
+	}
+	got := manifests[0].Matches[0].CweIDs
+	want := []string{"CWE-79", "CWE-89"}
+	if !equalStrings(got, want) {
+		t.Errorf("first manifest CweIDs = %v, want %v (List path missed the CWE overlay)", got, want)
+	}
+
+	// Second manifest: CWE only on related — must still propagate.
+	if len(manifests[1].Matches) != 1 {
+		t.Fatalf("second manifest: expected 1 match, got %d", len(manifests[1].Matches))
+	}
+	got = manifests[1].Matches[0].CweIDs
+	want = []string{"CWE-200"}
+	if !equalStrings(got, want) {
+		t.Errorf("second manifest CweIDs = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

\`GetVulnerabilityManifest\` extracts CWEs from the raw response body via an overlay (because the canonical \`v1beta1\` type doesn't carry them — see #5). \`ListVulnerabilityManifests\` skipped the overlay entirely, so any future caller of \`List\` would silently miss CWEs even though \`Get\` had them.

## Approach

Refactor: extract the per-manifest merge into \`mergeCwes()\`, reused by both \`applyCweOverlay\` (Get) and a new \`applyCweOverlayList\` (List). The list overlay struct mirrors the API response shape — \`items[*].spec.payload.matches[*].(vulnerability|relatedVulnerabilities).cwes\` — and is parsed from the same body the canonical decoder consumed.

\`ListVulnerabilityManifests\` is currently dormant (no callers) but the contract should be consistent across the API surface.

## Test

\`TestListVulnerabilityManifests_AppliesCweOverlay\` — list response with two manifests, the first with CWEs in both overlay slots (vulnerability + relatedVulnerabilities), the second only on related. Asserts deduped-union CWEs propagate to each manifest's first match.