### PR TITLE
fix(k8s): broaden fatal classification to all 4xx (#45)

### DIFF
--- a/pkg/k8s/rest_client.go
+++ b/pkg/k8s/rest_client.go
@@ -203,12 +203,14 @@ func (c *RESTClient) GetVulnerabilityManifest(ctx context.Context, namespace, na
 		}
 		return nil, fmt.Errorf("%w: K8s API 404 not for the requested object (likely missing namespace, unserved resource type, or broken path): %s", ErrFatalAPIRead, string(body))
 	}
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		// Auth failure won't recover within a single scan. Token rotation
-		// is picked up on the next request, so a transient 401 right at
-		// rotation boundary would flap at most once — but in steady state
-		// 401/403 means RBAC / token misconfig, and retrying for the
-		// full pollTimeout is a waste of budget.
+	// Any other 4xx is treated as fatal: 405 Method Not Allowed, 410
+	// Gone (resource type retired), 422 Unprocessable Entity, etc. These
+	// are deterministic client/cluster-config failures that don't fix
+	// themselves on retry. Pre-fix only 401/403 were classified as
+	// fatal, so a 410 from a retired CRD still got retried for the full
+	// pollTimeout (issue #45). 5xx and network errors stay transient
+	// — the retry loop will catch a server hiccup.
+	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
 		return nil, fmt.Errorf("%w: K8s API rejected GET (HTTP %d): %s", ErrFatalAPIRead, resp.StatusCode, string(body))
 	}
 	if resp.StatusCode != http.StatusOK {
@@ -312,12 +314,12 @@ func (c *RESTClient) Ping(ctx context.Context, namespace string) error {
 
 	body, _ := readBodyCapped(resp.Body)
 
-	switch resp.StatusCode {
-	case http.StatusOK:
+	switch {
+	case resp.StatusCode == http.StatusOK:
 		// Probe CRD exists by that name (extremely unlikely with our
 		// chosen name, but means we have read access — healthy).
 		return nil
-	case http.StatusNotFound:
+	case resp.StatusCode == http.StatusNotFound:
 		// Healthy ONLY when the 404 is the specific "probe object not
 		// found" Status. A 404 for a missing namespace or an unserved
 		// resource type would falsely keep readiness green even though
@@ -326,8 +328,11 @@ func (c *RESTClient) Ping(ctx context.Context, namespace string) error {
 			return nil
 		}
 		return fmt.Errorf("%w: k8s API 404 not for the probe object (likely missing namespace, unserved resource type, or broken path): %s", ErrFatalAPIRead, string(body))
-	case http.StatusUnauthorized, http.StatusForbidden:
-		return fmt.Errorf("%w: k8s API rejected VulnerabilityManifest GET (HTTP %d) — likely token rotation not picked up or RBAC missing", ErrFatalAPIRead, resp.StatusCode)
+	case resp.StatusCode >= 400 && resp.StatusCode < 500:
+		// Any other 4xx (401/403/405/410/422/...) is a deterministic
+		// client/cluster-config failure that won't recover by retrying.
+		// Mark fatal so the controller can short-circuit. See #45.
+		return fmt.Errorf("%w: k8s API rejected VulnerabilityManifest GET (HTTP %d) — token rotation, RBAC, or resource-type misconfig: %s", ErrFatalAPIRead, resp.StatusCode, string(body))
 	default:
 		return fmt.Errorf("k8s API ping returned %d: %s", resp.StatusCode, string(body))
 	}

--- a/pkg/k8s/rest_client_test.go
+++ b/pkg/k8s/rest_client_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -661,5 +662,86 @@ func TestListVulnerabilityManifests_AppliesCweOverlay(t *testing.T) {
 	want = []string{"CWE-200"}
 	if !equalStrings(got, want) {
 		t.Errorf("second manifest CweIDs = %v, want %v", got, want)
+	}
+}
+
+// TestGet_4xx_IsFatal pins issue #45: any 4xx response (not just
+// 401/403/non-object-404) wraps ErrFatalAPIRead so the controller can
+// short-circuit instead of retrying for the full pollTimeout. 405, 410,
+// 422 are the realistic ones — a CRD type that's been retired returns
+// 410 Gone, a misrouted request can return 405 Method Not Allowed.
+func TestGet_4xx_IsFatal(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+	}{
+		{"405 Method Not Allowed", http.StatusMethodNotAllowed},
+		{"410 Gone (resource type retired)", http.StatusGone},
+		{"422 Unprocessable Entity", http.StatusUnprocessableEntity},
+		{"401 Unauthorized (regression)", http.StatusUnauthorized},
+		{"403 Forbidden (regression)", http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.code)
+			}))
+			defer srv.Close()
+
+			c := NewRESTClient(srv.URL, StaticTokenSource("test-token"))
+			_, err := c.GetVulnerabilityManifest(context.Background(), "kubescape", "any-name")
+			if err == nil {
+				t.Fatalf("expected error for HTTP %d, got nil", tc.code)
+			}
+			if !errors.Is(err, ErrFatalAPIRead) {
+				t.Errorf("HTTP %d should wrap ErrFatalAPIRead so the poll loop bails fast, got plain error: %v", tc.code, err)
+			}
+		})
+	}
+}
+
+// TestGet_5xx_IsTransient confirms server errors stay UNwrapped so the
+// poll loop continues retrying. A 503 from a momentarily overloaded
+// apiserver shouldn't fail the scan.
+func TestGet_5xx_IsTransient(t *testing.T) {
+	for _, code := range []int{500, 502, 503, 504} {
+		t.Run(fmt.Sprintf("HTTP %d", code), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(code)
+			}))
+			defer srv.Close()
+
+			c := NewRESTClient(srv.URL, StaticTokenSource("test-token"))
+			_, err := c.GetVulnerabilityManifest(context.Background(), "kubescape", "any-name")
+			if err == nil {
+				t.Fatalf("expected error for HTTP %d, got nil", code)
+			}
+			if errors.Is(err, ErrFatalAPIRead) {
+				t.Errorf("HTTP %d must NOT wrap ErrFatalAPIRead — 5xx is transient and the poll loop should retry, not bail", code)
+			}
+		})
+	}
+}
+
+// TestPing_4xx_IsFatal mirrors TestGet_4xx_IsFatal for the readiness
+// probe path: any 4xx response should mark the pod NotReady.
+func TestPing_4xx_IsFatal(t *testing.T) {
+	for _, code := range []int{405, 410, 422} {
+		t.Run(fmt.Sprintf("HTTP %d", code), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(code)
+			}))
+			defer srv.Close()
+
+			c := NewRESTClient(srv.URL, StaticTokenSource("test-token"))
+			err := c.Ping(context.Background(), "kubescape")
+			if err == nil {
+				t.Fatalf("expected Ping to fail on HTTP %d", code)
+			}
+			if !errors.Is(err, ErrFatalAPIRead) {
+				t.Errorf("Ping HTTP %d should wrap ErrFatalAPIRead, got plain error: %v", code, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #45 — PR #41 introduced \`ErrFatalAPIRead\` but only wrapped 401/403 and non-object 404. Other 4xx — **405 Method Not Allowed**, **410 Gone** (resource type retired), **422 Unprocessable Entity** — fell through to the generic \`K8s API returned %d\` branch and stayed unwrapped.

Net effect: the controller's poll loop, which short-circuits on \`errors.Is(err, ErrFatalAPIRead)\`, kept retrying these deterministic failures for the full 10-minute \`pollTimeout\` before finally giving up. Exactly the behavior #41 was meant to prevent.

## Fix

Any 4xx other than benign 404 wraps \`ErrFatalAPIRead\`. 5xx and network errors stay **un**wrapped — those are transient and the retry loop should catch a server hiccup. Same change in \`GetVulnerabilityManifest\` and \`Ping\`.

## Tests

| Test | Cases | Asserts |
|---|---|---|
| \`TestGet_4xx_IsFatal\` | 401, 403, 405, 410, 422 | wraps \`ErrFatalAPIRead\` |
| \`TestGet_5xx_IsTransient\` | 500, 502, 503, 504 | does **not** wrap \`ErrFatalAPIRead\` |
| \`TestPing_4xx_IsFatal\` | 405, 410, 422 | wraps \`ErrFatalAPIRead\` |

The 401/403 entries in \`TestGet_4xx_IsFatal\` also guard against regression of #41's original classification.