### PR TITLE
fix(controller): persist completed scans with a fresh context during shutdown

### DIFF
--- a/pkg/scan/controller.go
+++ b/pkg/scan/controller.go
@@ -64,10 +64,26 @@ func NewController(store persistence.Store, scanner Scanner, k8sClient k8s.Clien
 	}
 }
 
-// failedWriteTimeout caps the time we'll spend persisting a terminal
-// Failed status during shutdown. Long enough for a healthy Redis to ACK,
-// short enough that a stuck Redis can't block process exit.
-const failedWriteTimeout = 5 * time.Second
+// terminalWriteTimeout caps the time we'll spend persisting a terminal
+// status (Finished or Failed) during shutdown. Long enough for a healthy
+// Redis to ACK, short enough that a stuck Redis can't block process exit.
+//
+// Both terminal writes — Failed (issue #29) and Finished (issue #49) —
+// use a fresh, uncancelled context with this timeout instead of the
+// inbound scan context. SIGTERM cancels scanCtx; reusing it for the
+// terminal write would race the Redis SET to context.Canceled and either
+// (a) leak Pending until TTL or (b) convert a completed scan into Failed.
+const terminalWriteTimeout = 5 * time.Second
+
+// publishFinished persists the report and Finished status using a fresh
+// context derived from background. See issue #49: a SIGTERM landing
+// between scan completion and SetFinished must NOT convert a completed
+// scan into Failed.
+func (c *controller) publishFinished(scanJobID string, report harbor.ScanReport) error {
+	writeCtx, cancel := context.WithTimeout(context.Background(), terminalWriteTimeout)
+	defer cancel()
+	return c.store.SetFinished(writeCtx, scanJobID, report)
+}
 
 func (c *controller) Scan(ctx context.Context, scanJobID string) error {
 	if err := c.scan(ctx, scanJobID); err != nil {
@@ -82,7 +98,7 @@ func (c *controller) Scan(ctx context.Context, scanJobID string) error {
 		// Reusing it for the store write would race the Redis SET to
 		// context.Canceled and leave the job Pending until TTL expiry.
 		// See issue #29.
-		writeCtx, cancel := context.WithTimeout(context.Background(), failedWriteTimeout)
+		writeCtx, cancel := context.WithTimeout(context.Background(), terminalWriteTimeout)
 		defer cancel()
 		if updateErr := c.store.UpdateStatus(writeCtx, scanJobID, persistence.Failed, err.Error()); updateErr != nil {
 			slog.Error("Failed to update scan job status",
@@ -177,7 +193,9 @@ func (c *controller) scan(ctx context.Context, scanJobID string) error {
 		// Atomic: publish report and Finished status in one store op so
 		// Harbor cannot poll a Finished status before the report lands,
 		// nor a Pending status while the report is already saved. See #31.
-		return c.store.SetFinished(ctx, scanJobID, report)
+		// Fresh ctx (issue #49): a SIGTERM here must not convert a
+		// completed scan into Failed.
+		return c.publishFinished(scanJobID, report)
 	} else if existing != nil {
 		staleSeenAt = existing.CreatedAt
 		slog.Info("Existing VulnerabilityManifest is stale, triggering fresh scan",
@@ -209,7 +227,12 @@ func (c *controller) scan(ctx context.Context, scanJobID string) error {
 	// Finished AND saves the report. Eliminates the crash window between
 	// UpdateReport and UpdateStatus that left reports invisible behind a
 	// stale Pending status (issue #31).
-	if err := c.store.SetFinished(ctx, scanJobID, report); err != nil {
+	//
+	// Fresh ctx (issue #49): scanCtx is cancelable on SIGTERM, but by the
+	// time we reach here the work is done and the only thing left is
+	// persisting success. Using the inbound ctx would race the Redis SET
+	// to context.Canceled and flip a completed scan to Failed.
+	if err := c.publishFinished(scanJobID, report); err != nil {
 		return err
 	}
 

--- a/pkg/scan/controller_test.go
+++ b/pkg/scan/controller_test.go
@@ -481,6 +481,115 @@ func TestScan_RedisFailedWrite_UsesUncancelledCtx(t *testing.T) {
 	}
 }
 
+// cancelOnGetK8sClient cancels the controller's inbound ctx at the moment
+// GetVulnerabilityManifest is invoked, then returns `manifest`. This models
+// SIGTERM landing exactly between "scan reads results" and "scan persists
+// Finished" — the window issue #49 covers.
+type cancelOnGetK8sClient struct {
+	manifest *k8s.VulnerabilityManifest
+	cancel   context.CancelFunc
+}
+
+func (c *cancelOnGetK8sClient) GetVulnerabilityManifest(_ context.Context, _, _ string) (*k8s.VulnerabilityManifest, error) {
+	c.cancel()
+	return c.manifest, nil
+}
+
+func (c *cancelOnGetK8sClient) ListVulnerabilityManifests(_ context.Context, _, _ string) ([]k8s.VulnerabilityManifest, error) {
+	return nil, nil
+}
+
+func (c *cancelOnGetK8sClient) Ping(_ context.Context, _ string) error { return nil }
+
+// TestScan_CompletedScanSurvivesSIGTERM pins issue #49.
+//
+// Issue #29 fixed the FAILED-write path: when scanCtx was cancelled by the
+// shutdown sequence, the wrapper's Failed-status write reused that
+// cancelled ctx and the Redis SET silently failed, leaving the job
+// Pending until TTL. The fix routes Failed writes through a fresh ctx
+// with a short timeout.
+//
+// Issue #49 is the same problem in the success direction. The reuse-path
+// and post-poll SetFinished both used the same cancelable scanCtx. If
+// SIGTERM landed between scan completion and the final SET, SetFinished
+// returned context.Canceled, scan() bubbled that up, and the wrapper
+// dutifully wrote Failed — converting a *successful* scan into a failure.
+//
+// The fix is symmetric to #29: publishFinished uses a fresh background
+// ctx with the same terminalWriteTimeout cap. This test exercises the
+// reuse path against a real-ish Redis (miniredis): a fresh manifest is
+// available, so the only k8s call is the initial Get; we cancel the
+// inbound ctx inside that Get to simulate SIGTERM landing right before
+// SetFinished. Pre-fix the job would end Failed; post-fix it ends
+// Finished with the report intact.
+func TestScan_CompletedScanSurvivesSIGTERM(t *testing.T) {
+	fixedNow := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	now = func() time.Time { return fixedNow }
+	t.Cleanup(func() { now = time.Now })
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	store := persistenceredis.NewStore(rdb)
+	freshCtx := context.Background()
+
+	job := persistence.ScanJob{
+		ID: "job-sigterm-success",
+		Request: harbor.ScanRequest{
+			Registry: harbor.Registry{URL: "https://core.harbor.domain"},
+			Artifact: harbor.Artifact{
+				Repository: "library/nginx",
+				Digest:     "sha256:abcdef0123456789",
+			},
+		},
+		Status: persistence.Queued,
+	}
+	if err := store.Create(freshCtx, job); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	scanCtx, cancel := context.WithCancel(context.Background())
+
+	scanner := &fakeScanner{}
+	fakeK8s := &cancelOnGetK8sClient{
+		manifest: &k8s.VulnerabilityManifest{
+			Name:        "nginx-fresh",
+			CreatedAt:   fixedNow.Add(-1 * time.Hour),
+			ToolVersion: "0.74.0",
+			Matches: []k8s.VulnMatch{
+				{ID: "CVE-2024-9999", Severity: "High", PkgName: "libfoo", PkgVersion: "1.0"},
+			},
+		},
+		cancel: cancel,
+	}
+
+	c := NewController(store, scanner, fakeK8s, "kubescape", 24*time.Hour)
+	if err := c.Scan(scanCtx, job.ID); err != nil {
+		t.Fatalf("Scan: %v — a SIGTERM landing during the final SetFinished must NOT fail a completed scan", err)
+	}
+
+	// Reuse path — scanner must not have been triggered.
+	if scanner.triggers != 0 {
+		t.Errorf("scanner.triggers = %d, want 0 (reuse path)", scanner.triggers)
+	}
+
+	// Read back with a FRESH ctx — scanCtx is cancelled.
+	got, err := store.Get(freshCtx, job.ID)
+	if err != nil {
+		t.Fatalf("post-scan Get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("job missing after Scan; expected Finished status with report")
+	}
+	if got.Status != persistence.Finished {
+		t.Errorf("status = %s, want Finished — a successful scan was flipped to failure by ctx cancellation during the terminal SetFinished (issue #49 regression)", got.Status)
+	}
+	if len(got.Report.Vulnerabilities) != 1 {
+		t.Errorf("report.Vulnerabilities = %d, want 1 — the completed report did not land", len(got.Report.Vulnerabilities))
+	}
+}
+
 // fatalErrK8sClient simulates a K8s client that always returns
 // k8s.ErrFatalAPIRead — e.g. a cluster where RBAC is misconfigured or
 // the namespace is wrong.


### PR DESCRIPTION
Closes #49.

## Summary

- Issue #29 fixed the FAILED-write path during graceful shutdown — using a cancelled `scanCtx` for the terminal `UpdateStatus(Failed)` raced the Redis SET to `context.Canceled` and left the job stuck Pending until TTL.
- Issue #49 is the same bug in the **success direction**: both `SetFinished` call sites (reuse-existing and post-poll) used the cancelable `scanCtx`. A SIGTERM landing between scan completion and the final SET caused the Redis op to fail with `context.Canceled`, `scan()` bubbled the error up, and the wrapper `Scan()` helpfully wrote `Failed` — flipping a *successful* scan into a failure.
- Fix mirrors the #29 shape: route both terminal `SetFinished` calls through a new `publishFinished` helper that uses a fresh `context.Background()` with a short timeout cap. Constant `failedWriteTimeout` renamed to `terminalWriteTimeout` to reflect its now-symmetric role.

## Code changes

- `pkg/scan/controller.go`:
  - Rename `failedWriteTimeout` → `terminalWriteTimeout` with extended doc covering both #29 and #49.
  - Add `publishFinished(scanJobID, report)` helper using a fresh background ctx.
  - Replace the two `c.store.SetFinished(ctx, ...)` call sites in `scan()` (reuse path + post-poll path) with `c.publishFinished(...)`.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./...` clean.
- [x] New regression test `TestScan_CompletedScanSurvivesSIGTERM` drives the reuse path against miniredis. A k8s client cancels the inbound ctx inside `GetVulnerabilityManifest` to model SIGTERM landing right between "scan reads results" and "scan persists Finished". Pre-fix the job ends `Failed` (verified); post-fix it ends `Finished` with the report intact.
- [x] Existing `TestScan_RedisFailedWrite_UsesUncancelledCtx` (issue #29) still passes — the constant rename didn't regress the symmetric path.