### PR TITLE
chart: derive listener port from service.port (closes #53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,13 @@ helm install harbor-scanner-kubescape ./charts/harbor-scanner-kubescape \
   --namespace harbor \
   --set tls.enabled=true \
   --set tls.secretName=harbor-scanner-kubescape-tls \
-  --set scanner.apiAddr=":8443" \
   --set service.port=8443
 ```
+
+`service.port` is the single source of truth for the listener port: the chart
+derives `SCANNER_API_ADDR=":<port>"`, the container port, and the probe targets
+from it, so switching to TLS only requires `service.port=8443` (no separate
+listener address to keep in sync).
 
 ### Graceful shutdown
 

--- a/charts/harbor-scanner-kubescape/Chart.yaml
+++ b/charts/harbor-scanner-kubescape/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: harbor-scanner-kubescape
 description: Harbor Scanner Adapter for Kubescape image vulnerability scanning
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.1.0"
 home: https://github.com/goharbor/harbor-scanner-kubescape
 sources:

--- a/charts/harbor-scanner-kubescape/templates/deployment.yaml
+++ b/charts/harbor-scanner-kubescape/templates/deployment.yaml
@@ -6,6 +6,9 @@
 {{- if and (eq (default "memory" .Values.persistence.backend) "redis") (not .Values.persistence.redis.url) (not .Values.persistence.redis.secretName) -}}
 {{- fail "persistence.backend=redis requires either persistence.redis.url or persistence.redis.secretName to be set." -}}
 {{- end -}}
+{{- if hasKey (default dict .Values.scanner) "apiAddr" -}}
+{{- fail "scanner.apiAddr has been removed; set service.port instead. The listener address is derived from service.port (e.g. service.port=8443 for TLS) so the container, Service, and probes stay in sync. See https://github.com/Onyx2406/harbor-scanner-kubescape/issues/53." -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,7 +36,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: SCANNER_API_ADDR
-              value: {{ .Values.scanner.apiAddr | quote }}
+              value: {{ printf ":%d" (int .Values.service.port) | quote }}
             - name: KUBEVULN_URL
               value: {{ .Values.scanner.kubevulnURL | quote }}
             - name: KUBEVULN_NAMESPACE

--- a/charts/harbor-scanner-kubescape/values.yaml
+++ b/charts/harbor-scanner-kubescape/values.yaml
@@ -18,13 +18,15 @@ fullnameOverride: ""
 
 service:
   type: ClusterIP
+  # Single source of truth for the listener port. The container binds to this
+  # port (SCANNER_API_ADDR=":<port>"), the named containerPort "api" is set to
+  # it, the Service exposes it, and the liveness/readiness probes target it.
+  # For TLS, switch to 8443 (or your preferred TLS port) along with
+  # tls.enabled=true; everything else follows automatically.
   port: 8080
 
 # Scanner adapter configuration
 scanner:
-  # Address to listen on. Default is plain HTTP on :8080. If tls.enabled is
-  # true, set this to ":8443" (or your preferred TLS port).
-  apiAddr: ":8080"
   # Base URL of the kubevuln service in the cluster
   kubevulnURL: "http://kubevuln.kubescape.svc.cluster.local:8080"
   # Kubernetes namespace where Kubescape components run
@@ -58,6 +60,9 @@ persistence:
 # from the referenced Secret (which must contain `tls.crt` and `tls.key` keys,
 # i.e. a kubernetes.io/tls Secret). When disabled, the scanner serves plain
 # HTTP and TLS termination is expected at the ingress / service mesh layer.
+#
+# Enabling TLS does not change the listener port on its own — set service.port
+# (e.g. to 8443) if you want the conventional HTTPS port.
 tls:
   enabled: false
   # Name of an existing kubernetes.io/tls Secret in the same namespace.


### PR DESCRIPTION
## Summary
- `scanner.apiAddr` and `service.port` were two independent knobs in the chart; the `values.yaml` comment told operators to flip `scanner.apiAddr` to `":8443"` for TLS without mentioning the matching `service.port` change, leaving containerPort / Service port / probes pinned at 8080 while the container listened on 8443.
- Collapsed to a single source of truth: removed `scanner.apiAddr`; the deployment now derives `SCANNER_API_ADDR=":<service.port>"` so the env, containerPort, Service port, and probe targets all follow one value.
- Added a `fail()` guard so existing values files that still set `scanner.apiAddr` get a clear error pointing at `service.port` and issue #53 instead of a silent regression.
- Bumped chart version to `0.2.0` (breaking values schema).
- README's TLS install example drops the now-redundant `--set scanner.apiAddr=":8443"` line.

Closes #53.

## Test plan
- [x] `helm lint ./charts/harbor-scanner-kubescape` — clean.
- [x] `helm template demo ./charts/harbor-scanner-kubescape` — defaults render `SCANNER_API_ADDR=":8080"`, `containerPort: 8080`, Service `port: 8080`, probes `scheme: HTTP`.
- [x] `helm template demo ./charts/harbor-scanner-kubescape --set tls.enabled=true --set tls.secretName=test-tls --set service.port=8443` — renders `SCANNER_API_ADDR=":8443"`, `containerPort: 8443`, Service `port: 8443`, probes `scheme: HTTPS`, `appProtocol: https`. (Original repro from the issue, no longer desyncs.)
- [x] `helm template ... --set service.port=9000` — every port location follows.
- [x] `helm template ... --set scanner.apiAddr=:8443 ...` — fails fast with `scanner.apiAddr has been removed; set service.port instead. ... See https://github.com/Onyx2406/harbor-scanner-kubescape/issues/53.`
- [x] Combined `persistence.backend=redis` + `tls.enabled=true` + `service.port=8443` renders consistently.