### PR TITLE
build(docker): bump builder to golang:1.25-alpine (closes #56)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 ARG VERSION=dev
 ARG COMMIT=none


### PR DESCRIPTION
## Summary
- \`go.mod\` requires \`go 1.25.0\`, but the Dockerfile was pinned to \`golang:1.22-alpine\`. \`docker build\` would fail with \`go.mod requires go >= 1.25.0\`, meaning the published container build path was broken even though host-side \`go build\` worked.
- Bump the builder stage to \`golang:1.25-alpine\`. No source changes.

Closes #56.

## Test plan
- [x] \`go build ./...\` on go1.25.0 — clean (verified locally).
- [x] Diff is the single \`FROM\` line; no transitive changes.