### PR TITLE
fix(persistence): keep Harbor registry credentials out of stored scan jobs (closes #55)

### DIFF
--- a/pkg/harbor/model.go
+++ b/pkg/harbor/model.go
@@ -63,9 +63,16 @@ func (s *Severity) UnmarshalJSON(b []byte) error {
 }
 
 // Registry represents a Docker Registry.
+//
+// Authorization is treated as transient credential material: the scan handler
+// captures it from the incoming Harbor request, strips it from any ScanRequest
+// it persists, and threads it directly to the kubevuln trigger via the
+// Controller. Persistence backends must therefore receive Registry values with
+// Authorization == "" — credentials are not part of stored job state. See
+// issue #55.
 type Registry struct {
 	URL           string `json:"url"`
-	Authorization string `json:"authorization"`
+	Authorization string `json:"authorization,omitempty"`
 }
 
 // Artifact represents a container image artifact.

--- a/pkg/http/api/v1/handler.go
+++ b/pkg/http/api/v1/handler.go
@@ -180,6 +180,16 @@ func (h *requestHandler) AcceptScanRequest(w http.ResponseWriter, r *http.Reques
 
 	scanJobID := uuid.New().String()
 
+	// Separate the registry credential from the rest of the scan request so
+	// the credential never reaches the store. kubevuln needs it once, at
+	// trigger time; persisting it (in particular in Redis with a 1h TTL,
+	// see issue #15) would mean Harbor's Basic/Bearer registry header sat in
+	// durable storage for up to an hour past its useful life. The auth is
+	// held in this goroutine's closure and handed directly to
+	// controller.Scan; the persisted job has Authorization == "". See #55.
+	registryAuth := scanRequest.Registry.Authorization
+	scanRequest.Registry.Authorization = ""
+
 	job := persistence.ScanJob{
 		ID:      scanJobID,
 		Request: scanRequest,
@@ -206,7 +216,7 @@ func (h *requestHandler) AcceptScanRequest(w http.ResponseWriter, r *http.Reques
 			if h.scanWG != nil {
 				defer h.scanWG.Done()
 			}
-			if err := h.controller.Scan(h.scanCtx, scanJobID); err != nil {
+			if err := h.controller.Scan(h.scanCtx, scanJobID, registryAuth); err != nil {
 				slog.Error("Async scan failed",
 					slog.String("scan_job_id", scanJobID),
 					slog.String("err", err.Error()),

--- a/pkg/http/api/v1/handler_test.go
+++ b/pkg/http/api/v1/handler_test.go
@@ -96,6 +96,95 @@ func TestAcceptScanRequest_Valid(t *testing.T) {
 	}
 }
 
+// TestAcceptScanRequest_StripsRegistryAuthFromStore pins issue #55: the
+// Harbor `registry.authorization` header MUST NOT survive into the persisted
+// ScanJob. It is needed transiently to authenticate the kubevuln trigger and
+// is threaded to the controller in-memory; the store sees Authorization == "".
+//
+// Failure mode this test guards against: Redis-backed deployments would keep
+// the raw Basic/Bearer header in durable state for up to the job TTL (1h by
+// default), well past its useful life.
+func TestAcceptScanRequest_StripsRegistryAuthFromStore(t *testing.T) {
+	store := memory.NewStore()
+	capture := &authCapturingController{called: make(chan struct{})}
+	handler := NewAPIHandler(
+		config.BuildInfo{Version: "test"},
+		config.Config{},
+		store,
+		capture,
+		nil, // scanCtx
+		nil, // scanWG
+	)
+
+	const sensitiveAuth = "Basic dXNlcjpzM2NyZXQ=" // user:s3cret
+	scanReq := harbor.ScanRequest{
+		Registry: harbor.Registry{
+			URL:           "https://core.harbor.domain",
+			Authorization: sensitiveAuth,
+		},
+		Artifact: harbor.Artifact{
+			Repository: "library/nginx",
+			Digest:     "sha256:abc123",
+		},
+	}
+	body, _ := json.Marshal(scanReq)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/scan", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+	var scanResp harbor.ScanResponse
+	if err := json.NewDecoder(w.Body).Decode(&scanResp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// The store must hold a job without the auth header.
+	stored, err := store.Get(context.Background(), scanResp.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if stored == nil {
+		t.Fatal("expected job in store, got nil")
+	}
+	if got := stored.Request.Registry.Authorization; got != "" {
+		t.Errorf("Authorization persisted to store = %q, want \"\" (issue #55 regression: credentials leaked into durable state)", got)
+	}
+
+	// The credential must still reach the controller's Scan call so kubevuln
+	// can authenticate; otherwise the strip would break scanning.
+	select {
+	case <-capture.called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("controller.Scan was not invoked within 2s")
+	}
+	if got := capture.gotAuth; got != sensitiveAuth {
+		t.Errorf("controller.Scan registryAuth = %q, want %q (auth was stripped but not threaded through)", got, sensitiveAuth)
+	}
+	if got := capture.gotJobID; got != scanResp.ID {
+		t.Errorf("controller.Scan scanJobID = %q, want %q", got, scanResp.ID)
+	}
+}
+
+// authCapturingController records the registryAuth and scanJobID passed to
+// Scan so a test can assert what the handler forwarded.
+type authCapturingController struct {
+	called   chan struct{}
+	gotAuth  string
+	gotJobID string
+	once     sync.Once
+}
+
+func (a *authCapturingController) Scan(_ context.Context, scanJobID string, registryAuth string) error {
+	a.once.Do(func() {
+		a.gotJobID = scanJobID
+		a.gotAuth = registryAuth
+		close(a.called)
+	})
+	return nil
+}
+
 func TestAcceptScanRequest_MissingFields(t *testing.T) {
 	store := memory.NewStore()
 	handler := NewAPIHandler(config.BuildInfo{}, config.Config{}, store, nil, nil, nil)
@@ -343,7 +432,7 @@ type blockingController struct {
 	store     persistence.Store
 }
 
-func (b *blockingController) Scan(ctx context.Context, scanJobID string) error {
+func (b *blockingController) Scan(ctx context.Context, scanJobID string, _ string) error {
 	b.gotCtx = ctx
 	close(b.started)
 	<-ctx.Done()

--- a/pkg/scan/controller.go
+++ b/pkg/scan/controller.go
@@ -36,8 +36,14 @@ var now = time.Now
 // 1. Check if a fresh VulnerabilityManifest CRD already exists for the image
 // 2. If yes, transform and return it
 // 3. If no, trigger kubevuln ScanCVE, then poll for the CRD
+//
+// registryAuth carries the Harbor registry credential (the raw
+// `registry.authorization` header) needed to authenticate the kubevuln
+// trigger. It is passed in-memory and is intentionally NOT read from the
+// stored ScanJob — the store is auth-stripped so credentials never sit in
+// durable state past the goroutine that's actively using them. See issue #55.
 type Controller interface {
-	Scan(ctx context.Context, scanJobID string) error
+	Scan(ctx context.Context, scanJobID string, registryAuth string) error
 }
 
 type controller struct {
@@ -85,8 +91,8 @@ func (c *controller) publishFinished(scanJobID string, report harbor.ScanReport)
 	return c.store.SetFinished(writeCtx, scanJobID, report)
 }
 
-func (c *controller) Scan(ctx context.Context, scanJobID string) error {
-	if err := c.scan(ctx, scanJobID); err != nil {
+func (c *controller) Scan(ctx context.Context, scanJobID string, registryAuth string) error {
+	if err := c.scan(ctx, scanJobID, registryAuth); err != nil {
 		slog.Error("Scan failed",
 			slog.String("scan_job_id", scanJobID),
 			slog.String("err", err.Error()),
@@ -119,7 +125,7 @@ func (c *controller) Scan(ctx context.Context, scanJobID string) error {
 // scanned). See issue #6.
 var ErrK8sUnavailable = fmt.Errorf("kubernetes client unavailable: cannot observe VulnerabilityManifest CRDs")
 
-func (c *controller) scan(ctx context.Context, scanJobID string) error {
+func (c *controller) scan(ctx context.Context, scanJobID string, registryAuth string) error {
 	job, err := c.store.Get(ctx, scanJobID)
 	if err != nil {
 		return err
@@ -211,7 +217,13 @@ func (c *controller) scan(ctx context.Context, scanJobID string) error {
 		slog.String("scan_job_id", scanJobID),
 	)
 
-	if err := c.scanner.TriggerScan(ctx, job.Request); err != nil {
+	// Build the kubevuln request just-in-time with the in-memory credential.
+	// The persisted job.Request has Authorization stripped (see handler /
+	// issue #55), so credentials never sit in the store; we re-attach them
+	// here in a local copy that lives only for the TriggerScan call.
+	scanReq := job.Request
+	scanReq.Registry.Authorization = registryAuth
+	if err := c.scanner.TriggerScan(ctx, scanReq); err != nil {
 		return fmt.Errorf("triggering kubevuln scan: %w", err)
 	}
 

--- a/pkg/scan/controller_test.go
+++ b/pkg/scan/controller_test.go
@@ -78,7 +78,7 @@ func TestScan_NoK8sClient_ReturnsError(t *testing.T) {
 	// before reaching it.
 	c := NewController(store, nil, nil, "kubescape", DefaultReuseTTL)
 
-	err := c.Scan(ctx, job.ID)
+	err := c.Scan(ctx, job.ID, "")
 	if err == nil {
 		t.Fatal("expected error when k8sClient is nil, got nil (Harbor would receive a false-clean report)")
 	}
@@ -221,7 +221,7 @@ func TestScan_FreshManifestIsReused(t *testing.T) {
 			scanner := &fakeScanner{}
 
 			c := NewController(store, scanner, fakeK8s, "kubescape", 24*time.Hour)
-			if err := c.Scan(ctx, job.ID); err != nil {
+			if err := c.Scan(ctx, job.ID, ""); err != nil {
 				t.Fatalf("Scan: %v", err)
 			}
 
@@ -281,7 +281,7 @@ func TestScan_StaleManifestTriggersFreshScan(t *testing.T) {
 	scanner := &triggerCancellingScanner{cancel: cancel}
 
 	c := NewController(store, scanner, fakeK8s, "kubescape", 24*time.Hour)
-	_ = c.Scan(ctx, job.ID) // expected to fail with context.Canceled after trigger
+	_ = c.Scan(ctx, job.ID, "") // expected to fail with context.Canceled after trigger
 
 	if scanner.triggers != 1 {
 		t.Errorf("scanner triggered %d time(s); stale manifest must trigger exactly one fresh scan", scanner.triggers)
@@ -296,6 +296,84 @@ type triggerCancellingScanner struct {
 func (s *triggerCancellingScanner) TriggerScan(_ context.Context, _ harbor.ScanRequest) error {
 	s.triggers++
 	s.cancel()
+	return nil
+}
+
+// TestScan_ForwardsRegistryAuthToTriggerScan_NotStored pins issue #55: the
+// in-memory registryAuth passed to Scan must reach the scanner's TriggerScan
+// call (so kubevuln can authenticate against the registry), but it must NOT
+// be persisted back into the store at any point — neither the initial Create
+// nor any UpdateStatus / SetFinished write may leave the credential in
+// durable state.
+func TestScan_ForwardsRegistryAuthToTriggerScan_NotStored(t *testing.T) {
+	fixedNow := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	now = func() time.Time { return fixedNow }
+	t.Cleanup(func() { now = time.Now })
+
+	store := memory.NewStore()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// Seed an auth-stripped job — that's the contract the handler enforces.
+	job := persistence.ScanJob{
+		ID: "job-auth-forward",
+		Request: harbor.ScanRequest{
+			Registry: harbor.Registry{URL: "https://core.harbor.domain"}, // no Authorization
+			Artifact: harbor.Artifact{
+				Repository: "library/nginx",
+				Digest:     "sha256:abcdef0123456789",
+			},
+		},
+		Status: persistence.Queued,
+	}
+	if err := store.Create(ctx, job); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// No existing CRD → controller triggers the scanner. The trigger fake
+	// records the request it saw and cancels the ctx so the subsequent poll
+	// bails out immediately instead of waiting 5s for a CRD that won't come.
+	scanner := &authRecordingScanner{cancel: cancel}
+	fakeK8s := &fakeK8sClient{manifest: nil}
+
+	const sensitiveAuth = "Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig"
+	c := NewController(store, scanner, fakeK8s, "kubescape", 24*time.Hour)
+	_ = c.Scan(ctx, job.ID, sensitiveAuth) // expected to fail with ctx.Canceled after trigger
+
+	if scanner.triggers != 1 {
+		t.Fatalf("scanner triggered %d time(s); expected exactly 1", scanner.triggers)
+	}
+	if got := scanner.seenAuth; got != sensitiveAuth {
+		t.Errorf("TriggerScan saw Authorization=%q, want %q (auth wasn't re-attached for the live scan)", got, sensitiveAuth)
+	}
+
+	// The store, on the other hand, must still hold an empty Authorization.
+	// The controller's UpdateStatus / Failed write must not have round-tripped
+	// the credential we just attached locally for the trigger call.
+	stored, err := store.Get(context.Background(), job.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := stored.Request.Registry.Authorization; got != "" {
+		t.Errorf("Authorization persisted to store = %q, want \"\" (issue #55 regression: controller leaked credential back into durable state)", got)
+	}
+}
+
+// authRecordingScanner records the harbor.ScanRequest it was triggered with
+// and cancels its context so the controller's subsequent poll loop returns
+// quickly. Used by TestScan_ForwardsRegistryAuthToTriggerScan_NotStored.
+type authRecordingScanner struct {
+	triggers int
+	seenAuth string
+	cancel   context.CancelFunc
+}
+
+func (s *authRecordingScanner) TriggerScan(_ context.Context, req harbor.ScanRequest) error {
+	s.triggers++
+	s.seenAuth = req.Registry.Authorization
+	if s.cancel != nil {
+		s.cancel()
+	}
 	return nil
 }
 
@@ -363,7 +441,7 @@ func TestScan_StaleManifestNotReturnedByPoll(t *testing.T) {
 	}
 
 	c := NewController(store, scanner, fakeK8s, "kubescape", 24*time.Hour)
-	if err := c.Scan(ctx, job.ID); err != nil {
+	if err := c.Scan(ctx, job.ID, ""); err != nil {
 		t.Fatalf("Scan: %v", err)
 	}
 
@@ -461,7 +539,7 @@ func TestScan_RedisFailedWrite_UsesUncancelledCtx(t *testing.T) {
 
 	// Run Scan with the already-cancelled ctx, mimicking what happens
 	// after main.go's cancelScans() fires on SIGTERM.
-	_ = c.Scan(cancelledCtx, job.ID)
+	_ = c.Scan(cancelledCtx, job.ID, "")
 
 	// Read the persisted state with a FRESH ctx — the cancelled one
 	// would itself fail the Redis GET. We want to know what was actually
@@ -565,7 +643,7 @@ func TestScan_CompletedScanSurvivesSIGTERM(t *testing.T) {
 	}
 
 	c := NewController(store, scanner, fakeK8s, "kubescape", 24*time.Hour)
-	if err := c.Scan(scanCtx, job.ID); err != nil {
+	if err := c.Scan(scanCtx, job.ID, ""); err != nil {
 		t.Fatalf("Scan: %v — a SIGTERM landing during the final SetFinished must NOT fail a completed scan", err)
 	}
 
@@ -637,7 +715,7 @@ func TestScan_FatalAPIError_BailsImmediately(t *testing.T) {
 	scanner := &fakeScanner{}
 
 	c := NewController(store, scanner, fakeK8s, "kubescape", DefaultReuseTTL)
-	err := c.Scan(ctx, job.ID)
+	err := c.Scan(ctx, job.ID, "")
 	if err == nil {
 		t.Fatal("expected Scan to fail with the fatal API error, got nil")
 	}
@@ -773,7 +851,7 @@ func TestScan_TransientInitError_StaleGuardStillHolds(t *testing.T) {
 	}
 
 	c := NewController(store, &fakeScanner{}, fakeK8s, "kubescape", DefaultReuseTTL)
-	if err := c.Scan(ctx, job.ID); err != nil {
+	if err := c.Scan(ctx, job.ID, ""); err != nil {
 		t.Fatalf("Scan: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- When `persistence.backend=redis`, the Redis adapter JSON-serialized the entire `ScanJob` — including Harbor's raw `registry.authorization` header — and wrote it with the job's TTL (1h default, see #15). Basic/Bearer registry credentials therefore sat in durable storage long past their useful life: kubevuln only needs the credential once at scan-trigger time, never during the polling phase.
- Move the credential to the live execution path only:
  - `AcceptScanRequest` captures `scanRequest.Registry.Authorization`, then **clears it** on the `ScanJob` it persists. The credential is held in the async goroutine's closure and threaded directly to the controller.
  - `Controller.Scan` grows a `registryAuth string` parameter (internal interface, all in-tree callers updated). Inside `scan()`, a local copy of `job.Request` is built just-in-time, the credential re-attached, and the local copy passed to `scanner.TriggerScan`. The persisted `ScanJob` in either backend never observes a non-empty `Authorization`.
  - `harbor.Registry.Authorization` is now `json:\"authorization,omitempty\"` and the type doc-comment spells out the transient-credential contract.
- Two regression tests pin the guarantee end-to-end.

Closes #55.

## Test plan
- [x] `TestAcceptScanRequest_StripsRegistryAuthFromStore` (new): POSTs `Basic dXNlcjpzM2NyZXQ=` — asserts the persisted job has `Authorization == \"\"` AND the credential reached `controller.Scan` via the new parameter.
- [x] `TestScan_ForwardsRegistryAuthToTriggerScan_NotStored` (new): drives the controller through a fake scanner — asserts `TriggerScan` saw the in-memory Bearer token AND the post-scan store read still has `Authorization == \"\"`.
- [x] `go test ./...` — all packages green.
- [x] `go test -race -count=1 ./...` — clean, no races introduced by the closure-based credential plumbing.
- [x] `go vet ./...` — clean.

## Notes on the contract
- `harbor.Registry.Authorization` remains a field on the wire type (Harbor still sends it on the inbound request). The contract is now: handler is the single site that reads it from the inbound request, then it's a parameter on `Controller.Scan` for the goroutine's lifetime. Anyone adding a future store write site must follow the same pattern — the type doc-comment now says so.
- No persistence-layer defensive double-strip: keeping the responsibility at the handler boundary is clearer and the regression tests cover the path.